### PR TITLE
fix: restrict safe_redirect to local paths only

### DIFF
--- a/oregoninvasiveshotline/pages/views.py
+++ b/oregoninvasiveshotline/pages/views.py
@@ -32,7 +32,7 @@ def edit(request, page_id=None):
             return safe_redirect(
                 request,
                 request.GET.get("next"),
-                fallback='pages-list'
+                fallback_url_name='pages-list'
             )
     else:
         form = FlatterPageForm(instance=page)

--- a/oregoninvasiveshotline/users/views.py
+++ b/oregoninvasiveshotline/users/views.py
@@ -86,7 +86,7 @@ def authenticate(request):
     return safe_redirect(
         request,
         request.GET.get('next'),
-        settings.LOGIN_REDIRECT_URL
+        fallback_url_name=settings.LOGIN_REDIRECT_URL
     )
 
 

--- a/oregoninvasiveshotline/utils/urls.py
+++ b/oregoninvasiveshotline/utils/urls.py
@@ -1,26 +1,24 @@
 import urllib.parse
 import logging
+from urllib.parse import urlsplit
 
 from django.shortcuts import redirect
-from django.utils.http import url_has_allowed_host_and_scheme
+from django.urls import reverse
 from django.contrib.sites.models import Site
 
 logger = logging.getLogger(__name__)
 
 
-def safe_redirect(request, proposed_redirect, fallback=""):
-    if url_has_allowed_host_and_scheme(
-        url=proposed_redirect,
-        allowed_hosts=request.get_host(),
-        require_https=request.is_secure(),
-    ):
-        return redirect(proposed_redirect)
-    elif proposed_redirect is not None and proposed_redirect.strip():
+def safe_redirect(request, proposed_redirect, fallback_url_name=""):
+    if proposed_redirect and proposed_redirect.strip():
+        parts = urlsplit(proposed_redirect)
+        if parts.scheme == "" and parts.netloc == "" and proposed_redirect.startswith("/"):
+            return redirect(proposed_redirect)
         msg = "Redirect to unsafe URL attempted '{}'"
         logger.warning(msg.format(proposed_redirect))
 
-    if fallback:
-        return redirect(fallback)
+    if fallback_url_name:
+        return redirect(reverse(fallback_url_name))
     return redirect('/')
 
 


### PR DESCRIPTION
## Description

Restricts safe_redirect to only allow local paths starting with `/`. Prevents open redirect vulnerabilities to external domains.

Fixes https://github.com/osu-cass/oregoninvasiveshotline/security/code-scanning/5

## Checklist

- [x] I have reviewed my code and made sure it meets the project's coding standards and followed the contributing guide.
- [x] I have tested my code thoroughly (if needed) to ensure it works as expected.
- [ ] I have documented my code (if needed) in the README.md.
- [x] I have checked that this PR doesn't introduce any accessibility issues.

## Type of Change

- [x] Security fix
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other