### PR TITLE
Switch logout to use POST request instead of GET

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -26,6 +26,9 @@
 		"CSS": { "formatter": { "language_server": { "name": "biome" } } },
 		"Python": {
 			"tab_size": 4
+		},
+		"HTML": {
+			"tab_size": 4
 		}
 	}
 }

--- a/oregoninvasiveshotline/templates/base.html
+++ b/oregoninvasiveshotline/templates/base.html
@@ -89,9 +89,9 @@
                                         <li><hr class="dropdown-divider"></li>
                                         <li>
                                         	<form action="{% url 'logout' %}" method="post" style="margin:0;">
-                                            {% csrf_token %}
-                                            <button type="submit" class="dropdown-item">Log out</button>
-                                          </form>
+                                            	{% csrf_token %}
+                                             	<button type="submit" class="dropdown-item">Log out</button>
+                                          	</form>
                                         </li>
                                     </ul>
                                 </li>

--- a/oregoninvasiveshotline/templates/base.html
+++ b/oregoninvasiveshotline/templates/base.html
@@ -87,7 +87,12 @@
                                             <li><a class="dropdown-item strong" href="{% url 'users-home' %}">My Account</a></li>
                                         {% endif %}
                                         <li><hr class="dropdown-divider"></li>
-                                        <li><a class="dropdown-item" href="{% url 'logout' %}">Log out</a></li>
+                                        <li>
+                                        	<form action="{% url 'logout' %}" method="post" style="margin:0;">
+                                            {% csrf_token %}
+                                            <button type="submit" class="dropdown-item">Log out</button>
+                                          </form>
+                                        </li>
                                     </ul>
                                 </li>
                             {% else %}


### PR DESCRIPTION
## Description

Switches the logout link in the navbar from a GET `<a>` tag to a POST `<form>` with a CSRF token. This fixes logout for Django 5+/6, which requires POST requests for the logout view.

Fixes [AB#4403](https://osu-cass.visualstudio.com/5e947304-3b40-453c-9c37-0635483f8d6d/_workitems/edit/4403)

## Checklist

- [x] I have reviewed my code and made sure it meets the project's coding standards and followed the contributing guide.
- [x] I have tested my code thoroughly (if needed) to ensure it works as expected.
- [ ] I have documented my code (if needed) in the README.md.
- [x] I have checked that this PR doesn't introduce any accessibility issues.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other (performance, refactoring, documentation, dependency, configuration, security)