### PR TITLE
Set timeout to 90 in docker

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -21,6 +21,7 @@ if [[ ${APP_SERVICE} == "wsgi" ]]; then
         --access-logfile '-' \
         --error-logfile '-' \
         --log-file '-' \
+        --timeout 90 \
         --access-logformat '%({x-forwarded-for}i)s %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"' \
         --forwarded-allow-ips="${LOAD_BALANCER_IPS:-127.0.0.1}" \
         -w 4 \


### PR DESCRIPTION
## Description
- Sets the timeout for the server to 90 rather than the default of 30, which was causing some long queries to crash. Note that the query itself probably needs to be optimized but that's something we'll need to look into later on.

Fixes [AB#4168](https://osu-cass.visualstudio.com/5e947304-3b40-453c-9c37-0635483f8d6d/_workitems/edit/4168)

## Checklist

- [x] I have reviewed my code and made sure it meets the project's coding standards and followed the contributing guide.
- [x] I have tested my code thoroughly (if needed) to ensure it works as expected.
- [x] I have documented my code (if needed) in the README.md.
- [x] I have checked that this PR doesn't introduce any accessibility issues.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other (performance, refactoring, documentation, dependency, configuration, security)
<!-- If database changes are included, please describe them: -->
