### PR TITLE
fix: tag scheduled container builds with correct branch

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -56,10 +56,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
             type=ref,event=pr
+            type=raw,value=main,enable=${{ steps.branch.outputs.ref == 'main' }}
+            type=raw,value=develop,enable=${{ steps.branch.outputs.ref == 'develop' }}
             type=raw,value=latest,enable=${{ steps.branch.outputs.ref == 'main' }}
-            type=raw,value=develop,enable=${{ steps.branch.outputs.ref == 'develop' && github.event_name != 'push' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
The matrix-based schedule build relied on type=ref,event=branch, which
reads github.ref. On schedule events github.ref is always the default
branch, so the develop matrix leg was being pushed to the :main tag.
Drive the branch tag from the matrix-resolved ref instead.

Signed-off-by: Lance Albertson <lance@osuosl.org>

---
name: Basic PR
about: A sample pull request template for the Oregon Invasive Species Hotline
title: ''
labels: ''
assignees: ''
---

## Description
<!-- Brief description of what this PR accomplishes and why it's needed. -->

Fixes # <!-- (issue number or azure board task ID like AB#12345) -->

## Checklist

- [ ] I have reviewed my code and made sure it meets the project's coding standards and followed the contributing guide.
- [ ] I have tested my code thoroughly (if needed) to ensure it works as expected.
- [ ] I have documented my code (if needed) in the README.md.
- [ ] I have checked that this PR doesn't introduce any accessibility issues.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other (performance, refactoring, documentation, dependency, configuration, security)
<!-- If database changes are included, please describe them: -->

## Screenshots (if applicable)
<!-- Please add screenshots for any UI changes. If not applicable, just delete this section -->
