### PR TITLE
Refine report wizard validation and layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,5 @@ Expand this dropdown to see the service architecture when working in production.
 ## Miscellaneous Notes
 
 Prefix archived or otherwise unused branches with `archive/`. These branches are typically used for experiments or other work that is not currently active. For example, `archive/experiment-with-new-approach`.
+
+In the frontend, when adding charahcter limits, use "limits.ts"

--- a/frontend/src/components/wizard/limits.ts
+++ b/frontend/src/components/wizard/limits.ts
@@ -1,0 +1,2 @@
+/** Maximum characters allowed for long free-text report fields. */
+export const REPORT_LONG_TEXT_MAX_LENGTH = 3000;

--- a/frontend/src/components/wizard/steps/one.tsx
+++ b/frontend/src/components/wizard/steps/one.tsx
@@ -16,37 +16,48 @@ export default function StepOne({
 	onResizingChange,
 }: StepOneProps) {
 	return (
-		<div className="row g-3 mt-1">
-			<ImageUpload
-				images={form.data.images}
-				captions={form.data.image_captions}
-				onResizingChange={onResizingChange}
-				onChange={(images, captions) => {
-					form.setData((prev) => ({
-						...prev,
-						images,
-						image_captions: captions,
-					}));
-					if (images.length === 0) {
-						onExifLocationChange(undefined);
-					}
-				}}
-				onExifLocationChange={onExifLocationChange}
-				optional
-			/>
-			<div className="col-12">
-				<Field
-					form={form}
-					name="find_description"
-					label="Details about what you found"
-					as="textarea"
-					textareaProps={{
-						rows: 5,
-						placeholder:
-							"Describe what you saw: estimated amount, size, life stage, condition, notable traits (color/markings, flowers/fruit), and anything else you feel is relevant",
+		<>
+			<h1 className="h5">Report an Invader</h1>
+
+			<p className="text-muted">
+				Use this form to report a possible invasive species in Oregon or get
+				help identifying an unknown species. The information you provide helps
+				experts identify your report as accurately as possible. Please include
+				as much detail as you can.
+			</p>
+
+			<div className="row g-3 mt-1">
+				<ImageUpload
+					images={form.data.images}
+					captions={form.data.image_captions}
+					onResizingChange={onResizingChange}
+					onChange={(images, captions) => {
+						form.setData((prev) => ({
+							...prev,
+							images,
+							image_captions: captions,
+						}));
+						if (images.length === 0) {
+							onExifLocationChange(undefined);
+						}
 					}}
+					onExifLocationChange={onExifLocationChange}
+					optional
 				/>
+				<div className="col-12">
+					<Field
+						form={form}
+						name="find_description"
+						label="Details about what you found"
+						as="textarea"
+						textareaProps={{
+							rows: 5,
+							placeholder:
+								"Describe what you saw: estimated amount, size, life stage, condition, notable traits (color/markings, flowers/fruit), and anything else you feel is relevant",
+						}}
+					/>
+				</div>
 			</div>
-		</div>
+		</>
 	);
 }

--- a/frontend/src/components/wizard/steps/one.tsx
+++ b/frontend/src/components/wizard/steps/one.tsx
@@ -1,5 +1,6 @@
 import Field from "../../forms/field";
 import ImageUpload from "../../forms/images/upload";
+import { REPORT_LONG_TEXT_MAX_LENGTH } from "../limits";
 import type { WizardStepProps } from "../types";
 
 interface StepOneProps extends WizardStepProps {
@@ -51,6 +52,7 @@ export default function StepOne({
 						label="Details about what you found"
 						as="textarea"
 						textareaProps={{
+							maxLength: REPORT_LONG_TEXT_MAX_LENGTH,
 							rows: 5,
 							placeholder:
 								"Describe what you saw: estimated amount, size, life stage, condition, notable traits (color/markings, flowers/fruit), and anything else you feel is relevant",

--- a/frontend/src/components/wizard/steps/three.tsx
+++ b/frontend/src/components/wizard/steps/three.tsx
@@ -1,5 +1,6 @@
 import { APIProvider } from "@vis.gl/react-google-maps";
 import Field from "../../forms/field";
+import { REPORT_LONG_TEXT_MAX_LENGTH } from "../limits";
 import LocationMap from "../locationMap";
 import type { WizardStepProps } from "../types";
 
@@ -71,6 +72,7 @@ export default function StepThree({
 					label="Anything else you can tell us about where you found this?"
 					as="textarea"
 					textareaProps={{
+						maxLength: REPORT_LONG_TEXT_MAX_LENGTH,
 						rows: 4,
 						placeholder:
 							"Note where in the area you spotted it (ditch, fence line, field edge, along water), any hazards nearby (power lines, soft ground, locked gates), and landmarks or access points.",

--- a/frontend/src/components/wizard/steps/two.tsx
+++ b/frontend/src/components/wizard/steps/two.tsx
@@ -4,6 +4,7 @@ import Lightbox from "yet-another-react-lightbox";
 import Zoom from "yet-another-react-lightbox/plugins/zoom";
 import FormCombobox from "../../forms/combobox";
 import Field from "../../forms/field";
+import { REPORT_LONG_TEXT_MAX_LENGTH } from "../limits";
 import type { CategoryWithSpecies, WizardStepProps } from "../types";
 import "yet-another-react-lightbox/styles.css";
 
@@ -209,6 +210,7 @@ export default function StepTwo({ form, items }: StepTwoProps) {
 					optional
 					as="textarea"
 					textareaProps={{
+						maxLength: REPORT_LONG_TEXT_MAX_LENGTH,
 						rows: 5,
 						placeholder:
 							"Describe how you identified this species (markings/size/behavior, tracks/sign, leaf/flower/fruit)",

--- a/oregoninvasiveshotline/reports/forms.py
+++ b/oregoninvasiveshotline/reports/forms.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-import re
 from typing import Any, List, cast
 
 from django.contrib.gis.geos import Point
@@ -26,12 +25,27 @@ from oregoninvasiveshotline.reports.tasks import (
 )
 
 ALLOWED_REPORT_STATES = ("Oregon", "Washington")
-PHONE_EXTENSION_PATTERN = re.compile(r"(?:\s*(?:x|ext\.?|extension)\s*\d+)\s*$", re.IGNORECASE)
-PHONE_ALLOWED_PATTERN = re.compile(r"^[\d\s()+.\-]*(?:\s*(?:x|ext\.?|extension)\s*\d+)?$", re.IGNORECASE)
 PHONE_VALIDATION_ERROR = (
     "Enter a phone number with at least 10 digits. You may use spaces, parentheses, "
     "hyphens, periods, plus signs, or an extension."
 )
+PHONE_ALLOWED_CHARACTERS = set("0123456789 \t\r\n()+.-")
+PHONE_EXTENSION_MARKERS = ("extension", "ext.", "ext", "x")
+
+
+def split_phone_extension(phone: str) -> tuple[str, str]:
+    """Split a phone number from a trailing extension marker."""
+    lower_phone = phone.lower()
+    for marker in PHONE_EXTENSION_MARKERS:
+        marker_start = lower_phone.rfind(marker)
+        if marker_start == -1:
+            continue
+
+        extension = phone[marker_start + len(marker):].strip()
+        if extension.isdigit():
+            return phone[:marker_start].strip(), extension
+
+    return phone, ""
 
 
 def validate_phone_number(value: str) -> str:
@@ -40,11 +54,11 @@ def validate_phone_number(value: str) -> str:
     if not phone:
         return phone
 
-    if not PHONE_ALLOWED_PATTERN.fullmatch(phone):
+    phone_without_extension, _ = split_phone_extension(phone)
+    if any(char not in PHONE_ALLOWED_CHARACTERS for char in phone_without_extension):
         raise forms.ValidationError(PHONE_VALIDATION_ERROR)
 
-    phone_without_extension = PHONE_EXTENSION_PATTERN.sub("", phone)
-    digit_count = len(re.sub(r"\D", "", phone_without_extension))
+    digit_count = sum(char.isdigit() for char in phone_without_extension)
     if digit_count < 10:
         raise forms.ValidationError(PHONE_VALIDATION_ERROR)
 

--- a/oregoninvasiveshotline/reports/forms.py
+++ b/oregoninvasiveshotline/reports/forms.py
@@ -29,7 +29,7 @@ PHONE_VALIDATION_ERROR = (
     "Enter a phone number with at least 10 digits. You may use spaces, parentheses, "
     "hyphens, periods, plus signs, or an extension."
 )
-PHONE_ALLOWED_CHARACTERS = set("0123456789 \t\r\n()+.-")
+PHONE_ALLOWED_CHARACTERS = set("0123456789 ()+.-")
 PHONE_EXTENSION_MARKERS = ("extension", "ext.", "ext", "x")
 
 

--- a/oregoninvasiveshotline/reports/forms.py
+++ b/oregoninvasiveshotline/reports/forms.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+import re
 from typing import Any, List, cast
 
 from django.contrib.gis.geos import Point
@@ -25,6 +26,30 @@ from oregoninvasiveshotline.reports.tasks import (
 )
 
 ALLOWED_REPORT_STATES = ("Oregon", "Washington")
+PHONE_EXTENSION_PATTERN = re.compile(r"(?:\s*(?:x|ext\.?|extension)\s*\d+)\s*$", re.IGNORECASE)
+PHONE_ALLOWED_PATTERN = re.compile(r"^[\d\s()+.\-]*(?:\s*(?:x|ext\.?|extension)\s*\d+)?$", re.IGNORECASE)
+PHONE_VALIDATION_ERROR = (
+    "Enter a phone number with at least 10 digits. You may use spaces, parentheses, "
+    "hyphens, periods, plus signs, or an extension."
+)
+
+
+def validate_phone_number(value: str) -> str:
+    """Validate a common phone number format while allowing optional extensions."""
+    phone = value.strip()
+    if not phone:
+        return phone
+
+    if not PHONE_ALLOWED_PATTERN.fullmatch(phone):
+        raise forms.ValidationError(PHONE_VALIDATION_ERROR)
+
+    phone_without_extension = PHONE_EXTENSION_PATTERN.sub("", phone)
+    digit_count = len(re.sub(r"\D", "", phone_without_extension))
+    if digit_count < 10:
+        raise forms.ValidationError(PHONE_VALIDATION_ERROR)
+
+    return phone
+
 
 def get_county(point: Point):
     """Return the first county polygon that intersects a point.
@@ -333,14 +358,21 @@ class ReportForm(forms.ModelForm):
         return report
 
 
+REPORT_LONG_TEXT_MAX_LENGTH = 3000
+
+
 class NewReportForm(forms.Form):
 
-    find_description = forms.CharField()
+    find_description = forms.CharField(max_length=REPORT_LONG_TEXT_MAX_LENGTH)
     category = forms.ModelChoiceField(queryset=Category.objects.all())
     species = forms.ModelChoiceField(queryset=Species.objects.all(), required=False)
     is_species_unknown = forms.BooleanField(required=False, label='Species unknown')
-    identification_process = forms.CharField(required=False, widget=forms.Textarea)
-    location_description = forms.CharField()
+    identification_process = forms.CharField(
+        max_length=REPORT_LONG_TEXT_MAX_LENGTH,
+        required=False,
+        widget=forms.Textarea,
+    )
+    location_description = forms.CharField(max_length=REPORT_LONG_TEXT_MAX_LENGTH)
     # Long/Lat are required, but we instead just set an error message on
     # latitude that's a bit more human friendly later on in the clean method.
     latitude = forms.FloatField(required=False)
@@ -362,6 +394,10 @@ class NewReportForm(forms.Form):
         email = self.cleaned_data['email']
         email = email.lower()
         return email
+
+    def clean_phone(self):
+        """Validate the optional reporter phone number."""
+        return validate_phone_number(self.cleaned_data.get('phone', ''))
 
     def clean(self):
         """Validate species-selection rules and required map coordinates.

--- a/oregoninvasiveshotline/reports/tests.py
+++ b/oregoninvasiveshotline/reports/tests.py
@@ -29,7 +29,15 @@ from oregoninvasiveshotline.species.models import Category, Severity, Species
 from oregoninvasiveshotline.notifications.models import UserNotificationQuery
 from oregoninvasiveshotline.users.models import User
 
-from .forms import InviteForm, ManagementForm, NewReportForm, ReportForm, ReportSearchForm
+from .forms import (
+    InviteForm,
+    ManagementForm,
+    NewReportForm,
+    PHONE_VALIDATION_ERROR,
+    REPORT_LONG_TEXT_MAX_LENGTH,
+    ReportForm,
+    ReportSearchForm,
+)
 from .models import Invite, Report, receiver__generate_icon
 from .views import _export
 
@@ -768,10 +776,10 @@ class ReportFormTest(TransactionTestCase, UserMixin):
 
 class NewReportFormTest(TransactionTestCase):
 
-    def test_identification_process_not_required(self):
-        """Ensure the wizard form validates without an identification process note."""
+    def _valid_form_data(self, **overrides):
+        """Return valid default wizard form data with optional overrides."""
         category = make(Category)
-        form = NewReportForm({
+        data = {
             "find_description": "Found near trail edge",
             "category": category.pk,
             "location_description": "Near mile marker 3",
@@ -780,7 +788,39 @@ class NewReportFormTest(TransactionTestCase):
             "email": "foo@example.com",
             "first_name": "Foo",
             "last_name": "Bar",
-        })
+        }
+        data.update(overrides)
+        return data
+
+    def assert_field_has_error_code(self, form, field_name, error_code):
+        """Assert that a form field has an error with the expected code."""
+        field_errors = form.errors.as_data().get(field_name, [])
+        self.assertTrue(
+            any(error.code == error_code for error in field_errors),
+            f"Expected {field_name!r} to have an error with code {error_code!r}.",
+        )
+
+    def assert_phone_error(self, form):
+        """Assert that the phone field has the expected validation error."""
+        field_errors = form.errors.as_data().get("phone", [])
+        self.assertTrue(
+            any(error.message == PHONE_VALIDATION_ERROR for error in field_errors),
+            "Expected phone to have the configured validation error.",
+        )
+
+    def test_complete_form_data_validates(self):
+        """Ensure a full wizard form submission validates successfully."""
+        form = NewReportForm(self._valid_form_data(
+            identification_process="Compared flower color and leaf shape to the field guide.",
+            phone="+1 (541) 555-1212 ext. 123",
+            questions="Can someone confirm whether removal is recommended?",
+        ))
+
+        self.assertTrue(form.is_valid())
+
+    def test_identification_process_not_required(self):
+        """Ensure the wizard form validates without an identification process note."""
+        form = NewReportForm(self._valid_form_data())
         self.assertTrue(form.is_valid())
 
         with (
@@ -791,21 +831,71 @@ class NewReportFormTest(TransactionTestCase):
 
         self.assertEqual(report.identification_process, "")
 
+    def test_long_text_fields_validate_max_length(self):
+        """Ensure long wizard text fields reject values over the configured limit."""
+        too_long = "a" * (REPORT_LONG_TEXT_MAX_LENGTH + 1)
+        fields = [
+            "find_description",
+            "identification_process",
+            "location_description",
+        ]
+
+        for field_name in fields:
+            with self.subTest(field_name=field_name):
+                form = NewReportForm(self._valid_form_data(**{field_name: too_long}))
+
+                self.assertFalse(form.is_valid())
+                self.assert_field_has_error_code(form, field_name, "max_length")
+
+    def test_phone_is_optional(self):
+        """Ensure the optional phone field accepts blank values."""
+        form = NewReportForm(self._valid_form_data(phone=""))
+
+        self.assertTrue(form.is_valid())
+
+    def test_phone_accepts_common_formats(self):
+        """Ensure common phone number formats validate successfully."""
+        phone_numbers = [
+            "(541) 555-1212",
+            "541.555.1212",
+            "+1 541-555-1212",
+            "541 555 1212 x99",
+            "541-555-1212 ext. 123",
+            "541-555-1212 extension 12345",
+        ]
+
+        for phone_number in phone_numbers:
+            with self.subTest(phone_number=phone_number):
+                form = NewReportForm(self._valid_form_data(phone=phone_number))
+
+                self.assertTrue(form.is_valid())
+
+    def test_phone_rejects_invalid_values(self):
+        """Ensure phone validation rejects short numbers and invalid characters."""
+        phone_numbers = [
+            "555-1212",
+            "541-555-1212 office",
+            "541-555-1212 ext abc",
+            "541-555-1212 #123",
+        ]
+
+        for phone_number in phone_numbers:
+            with self.subTest(phone_number=phone_number):
+                form = NewReportForm(self._valid_form_data(phone=phone_number))
+
+                self.assertFalse(form.is_valid())
+                self.assert_phone_error(form)
+
     def test_save_maps_wizard_fields(self):
         """Ensure wizard fields are persisted to report and follow-up comment records."""
-        category = make(Category)
-        form = NewReportForm({
-            "find_description": "Leafy plant with white flowers",
-            "category": category.pk,
-            "identification_process": "Compared leaves and flower clusters with a field guide",
-            "location_description": "Along roadside ditch",
-            "latitude": 44.0521,
-            "longitude": -123.0867,
-            "email": "foo@example.com",
-            "first_name": "Foo",
-            "last_name": "Bar",
-            "questions": "Can someone confirm species?",
-        })
+        form = NewReportForm(self._valid_form_data(
+            find_description="Leafy plant with white flowers",
+            identification_process="Compared leaves and flower clusters with a field guide",
+            location_description="Along roadside ditch",
+            latitude=44.0521,
+            longitude=-123.0867,
+            questions="Can someone confirm species?",
+        ))
         self.assertTrue(form.is_valid())
 
         with (

--- a/oregoninvasiveshotline/static/css/main.css
+++ b/oregoninvasiveshotline/static/css/main.css
@@ -14,6 +14,10 @@ small {
     font-weight:normal;
 }
 
+.x-small {
+    font-size: .7em;
+}
+
 kbd {
     background:#fff;
     color:#000;
@@ -408,15 +412,6 @@ blockquote {
 .location blockquote {
     margin-top:5px;
     font-size:12px;
-}
-
-.report-status-info {
-    float:right;
-    padding:5px;
-    margin-left:5px;
-    margin-bottom:5px;
-    font-size:11px;
-    background-color:#fcf8e3;
 }
 
 .table-striped2>tbody>tr:nth-of-type(even) {

--- a/oregoninvasiveshotline/templates/reports/detail.html
+++ b/oregoninvasiveshotline/templates/reports/detail.html
@@ -26,36 +26,38 @@ Report #{{ report.pk }} - {{ report }}
             {% endif %}
         </div>
 
-        <p class="report-status-info">
-            {% if report.has_specimen %}
-                <em>Submitter has sample</em><br />
-            {% else %}
-                <em>Submitter does not have a specimen</em><br />
-            {% endif %}
-
-            {% if user|can_create_comment:report %}
-                <strong>Submitted by:</strong> {{ report.created_by.first_name }} {{ report.created_by.last_name }} ({{ report.created_by.email }}) {% if report.created_by.phone %}{{ report.created_by.phone }}{% endif %}<br />
-            {% endif %}
-
-            {% if report.edrr_status %}
-                <strong title="Early Detection and Rapid Response">EDRR Status:</strong> {{ report.get_edrr_status_display }}
-                <br />
-            {% endif %}
-
-            {% if user.is_active %}
-                {% if report.is_public %}
-                    <span class="bi bi-eye" title="Public"></span>
+        <div class="d-flex flex-column flex-sm-row justify-content-between gap-2 align-items-sm-center mb-2">
+            <h4 class="mb-0">Description of specimen</h4>
+            <p class="x-small p-2 mb-0" style="background-color:#fcf8e3;">
+                {% if report.has_specimen %}
+                    <em>Submitter has sample</em><br />
+                {% else %}
+                    <em>Submitter does not have a specimen</em><br />
                 {% endif %}
-                {% if report.actual_species %}
-                    <span class="bi bi-check-circle" title="Confirmed"></span>
+
+                {% if user|can_create_comment:report %}
+                    <strong>Submitted by:</strong> {{ report.created_by.first_name }} {{ report.created_by.last_name }} ({{ report.created_by.email }}) {% if report.created_by.phone %}{{ report.created_by.phone }}{% endif %}<br />
                 {% endif %}
-                {% if report.is_archived %}
-                    <span class="bi bi-archive" title="Archived"></span>
+
+                {% if report.edrr_status %}
+                    <strong title="Early Detection and Rapid Response">EDRR Status:</strong> {{ report.get_edrr_status_display }}
+                    <br />
                 {% endif %}
-            {% endif %}
-        </p>
-        <h4>Description of specimen</h4>
-        <blockquote>{{ report.description|default:"No description provided"|linebreaksbr }}</blockquote>
+
+                {% if user.is_active %}
+                    {% if report.is_public %}
+                        <span class="bi bi-eye" title="Public"></span>
+                    {% endif %}
+                    {% if report.actual_species %}
+                        <span class="bi bi-check-circle" title="Confirmed"></span>
+                    {% endif %}
+                    {% if report.is_archived %}
+                        <span class="bi bi-archive" title="Archived"></span>
+                    {% endif %}
+                {% endif %}
+            </p>
+        </div>
+        <blockquote class="text-break">{{ report.description|default:"No description provided"|linebreaksbr }}</blockquote>
 
         {% if report.identification_process %}
 	        <h4 class="h6">Identification process:</h4>
@@ -134,7 +136,7 @@ Report #{{ report.pk }} - {{ report }}
             <h4>Location</h4>
             <div id="map-canvas" style="height:200px"></div>
             {% if report.location %}
-                <blockquote>{{ report.location|linebreaksbr }}</blockquote>
+                <blockquote class="text-break">{{ report.location|linebreaksbr }}</blockquote>
             {% endif %}
         </div>
 


### PR DESCRIPTION
## Summary
- Add shared character limits for long report text fields and enforce them in Django and the wizard UI.
- Add backend phone validation with a clearer error message for report submissions.
- Rework the report detail header/status layout to use Bootstrap flex utilities instead of a float-based custom rule.
- Clean up related wizard and frontend field handling to keep validation and presentation aligned.

## Screenshots

Current:
<img width="1647" height="593" alt="image" src="https://github.com/user-attachments/assets/26f1f047-ecd3-4c9a-a5bb-eae1c27af8df" />

Fixed:
<img width="1345" height="618" alt="image" src="https://github.com/user-attachments/assets/80403340-f7ba-4f8b-97b4-46da5e9dc5a1" />

New phone number validation:
<img width="746" height="136" alt="image" src="https://github.com/user-attachments/assets/c1dde5d8-a8a4-4d1f-851a-d50439d71424" />


## Checklist

- [x] I have reviewed my code and made sure it meets the project's coding standards and followed the contributing guide.
- [x] I have tested my code thoroughly (if needed) to ensure it works as expected.
- [x] I have documented my code (if needed) in the README.md.
- [x] I have checked that this PR doesn't introduce any accessibility issues.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other (performance, refactoring, documentation, dependency, configuration, security)
<!-- If database changes are included, please describe them: -->