### PR TITLE
Cache bust static assets

### DIFF
--- a/oregoninvasiveshotline/settings.py
+++ b/oregoninvasiveshotline/settings.py
@@ -39,7 +39,7 @@ env = environ.Env(
     CELERY_TASK_ALWAYS_EAGER=(bool, False),
     STATIC_ROOT=(str, ''),
     MEDIA_ROOT=(str, ''),
-    STATICFILES_STORAGE=(str, 'django.contrib.staticfiles.storage.StaticFilesStorage'),
+    STATICFILES_STORAGE=(str, 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'),
     CSRF_COOKIE_SECURE=(bool, True),
     SESSION_COOKIE_SECURE=(bool, True),
     SECURE_PROXY_SSL_HEADER=(str, ''),
@@ -133,6 +133,16 @@ STATIC_URL = '/static/'
 MEDIA_ROOT = env('MEDIA_ROOT', default=os.path.join(FILE_ROOT, 'media'))  # pyright: ignore
 MEDIA_URL = '/media/'
 STATICFILES_STORAGE = env('STATICFILES_STORAGE')
+if ENV == 'test':
+    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": STATICFILES_STORAGE,
+    },
+}
 
 # TODO: Temporary increase to 5MB to support many file uploads (see AB#4342);
 #   need to evaluate if this can be reduced after implementing a new file upload mechanism


### PR DESCRIPTION
## Summary
- Configure Django staticfiles to use a manifest-backed storage class so static asset URLs include content hashes after collectstatic.
- Force manifest URL resolution even when DEBUG is true, which keeps local Docker and production-style builds from rendering unhashed paths like `/static/css/main.css`.
- Wire the selected staticfiles backend through Django's STORAGES setting so `{% static %}` references resolve to cache-busted paths.

Fixes [AB#4525](https://osu-cass.visualstudio.com/5e947304-3b40-453c-9c37-0635483f8d6d/_workitems/edit/4525)

## Checklist

- [x] I have reviewed my code and made sure it meets the project's coding standards and followed the contributing guide.
- [x] I have tested my code thoroughly (if needed) to ensure it works as expected.
- [x] I have documented my code (if needed) in the README.md.
- [x] I have checked that this PR doesn't introduce any accessibility issues.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Other (performance, refactoring, documentation, dependency, configuration, security)
<!-- If database changes are included, please describe them: -->
