### PR TITLE
Fix playwright ci

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,6 +5,10 @@ on:
     branches: [main, develop]
   pull_request:
 
+concurrency:
+  group: playwright-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     timeout-minutes: 60
@@ -50,8 +54,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        timeout-minutes: 15
+        run: DEBUG=pw:install npx playwright install --with-deps
 
       - name: Run Playwright tests
         run: npx playwright test

--- a/frontend/src/components/wizard/locationMap.tsx
+++ b/frontend/src/components/wizard/locationMap.tsx
@@ -87,6 +87,7 @@ export default function LocationMap({
 				setLocationPlacementType(LocationPlacementType.OTHER);
 				map?.setZoom(6);
 			},
+			{ maximumAge: 0, timeout: 10_000 },
 		);
 	};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.4.10",
-				"@playwright/test": "^1.58.2",
+				"@playwright/test": "^1.60.0",
 				"@types/google.maps": "^3.58.1",
 				"@types/node": "^25.5.0",
 				"@types/react": "^19.2.14",
@@ -1009,13 +1009,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-			"integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.58.2"
+				"playwright": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -2429,13 +2429,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-			"integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.58.2"
+				"playwright-core": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -2448,9 +2448,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.10",
-		"@playwright/test": "^1.58.2",
+		"@playwright/test": "^1.60.0",
 		"@types/google.maps": "^3.58.1",
 		"@types/node": "^25.5.0",
 		"@types/react": "^19.2.14",

--- a/tests/wizard/exif-location.spec.ts
+++ b/tests/wizard/exif-location.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from "@playwright/test";
 import {
 	expectProgress,
 	fillStepOne,
-	mockCurrentLocationSuccess,
 	openWizard,
 	selectFirstComboboxOption,
 	TEST_COORDS,
@@ -10,11 +9,15 @@ import {
 	TEST_IMAGE_DSCN0042,
 } from "./shared";
 
+test.use({
+	geolocation: TEST_COORDS,
+	permissions: ["geolocation"],
+});
+
 test.describe("report wizard", () => {
 	test("uses photo EXIF data for the initial location", async ({ page }) => {
 		const wizard = page.getByRole("main");
 
-		await mockCurrentLocationSuccess(page);
 		await openWizard(page);
 		await page
 			.locator("#file-drop-input")
@@ -76,7 +79,6 @@ test.describe("report wizard", () => {
 	}) => {
 		const wizard = page.getByRole("main");
 
-		await mockCurrentLocationSuccess(page);
 		await openWizard(page);
 		await page
 			.locator("#file-drop-input")

--- a/tests/wizard/exif-location.spec.ts
+++ b/tests/wizard/exif-location.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
 	expectProgress,
 	fillStepOne,
+	mockCurrentLocationSuccess,
 	openWizard,
 	selectFirstComboboxOption,
 	TEST_COORDS,
@@ -13,6 +14,7 @@ test.describe("report wizard", () => {
 	test("uses photo EXIF data for the initial location", async ({ page }) => {
 		const wizard = page.getByRole("main");
 
+		await mockCurrentLocationSuccess(page);
 		await openWizard(page);
 		await page
 			.locator("#file-drop-input")
@@ -74,6 +76,7 @@ test.describe("report wizard", () => {
 	}) => {
 		const wizard = page.getByRole("main");
 
+		await mockCurrentLocationSuccess(page);
 		await openWizard(page);
 		await page
 			.locator("#file-drop-input")

--- a/tests/wizard/full-wizard.spec.ts
+++ b/tests/wizard/full-wizard.spec.ts
@@ -2,20 +2,22 @@ import { expect, test } from "@playwright/test";
 import {
 	expectProgress,
 	fillStepOne,
-	mockCurrentLocationSuccess,
 	openWizard,
 	selectFirstComboboxOption,
 	TEST_COORDS,
 	TEST_IMAGE_PATH,
 } from "./shared";
 
+test.use({
+	geolocation: TEST_COORDS,
+	permissions: ["geolocation"],
+});
+
 test.describe("report wizard", () => {
 	test("completes the full wizard with strong field and button assertions", async ({
 		page,
 	}) => {
 		const wizard = page.getByRole("main");
-
-		await mockCurrentLocationSuccess(page);
 
 		await test.step("shows the full initial step 1 state", async () => {
 			await openWizard(page);

--- a/tests/wizard/full-wizard.spec.ts
+++ b/tests/wizard/full-wizard.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
 	expectProgress,
 	fillStepOne,
+	mockCurrentLocationSuccess,
 	openWizard,
 	selectFirstComboboxOption,
 	TEST_COORDS,
@@ -13,6 +14,8 @@ test.describe("report wizard", () => {
 		page,
 	}) => {
 		const wizard = page.getByRole("main");
+
+		await mockCurrentLocationSuccess(page);
 
 		await test.step("shows the full initial step 1 state", async () => {
 			await openWizard(page);

--- a/tests/wizard/location-error-dialog.spec.ts
+++ b/tests/wizard/location-error-dialog.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
 	expectProgress,
 	fillStepOne,
+	mockCurrentLocationFailure,
 	openWizard,
 	selectFirstComboboxOption,
 	TEST_IMAGE_DSCN0042,
@@ -10,21 +11,12 @@ import {
 test.describe("report wizard", () => {
 	test("shows a dialog when current location cannot be retrieved", async ({
 		page,
-		context,
-		browserName,
 	}) => {
 		const wizard = page.getByRole("main");
 		const locationErrorMessage =
 			"Unable to retrieve your location. Please allow location access and try again.";
 
-		// Setting geo to null only works in firefox, and clear permissions only works in Safari.
-		// (Both works in chrome)
-		if (browserName === "firefox") {
-			await context.setGeolocation(null);
-		} else {
-			await context.clearPermissions();
-		}
-
+		await mockCurrentLocationFailure(page, locationErrorMessage);
 		await openWizard(page);
 		await page
 			.locator("#file-drop-input")

--- a/tests/wizard/shared.ts
+++ b/tests/wizard/shared.ts
@@ -1,5 +1,7 @@
+/// <reference lib="dom" />
+
 import path from "node:path";
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 export const WIZARD_URL = "/reports/create-new";
 export const TEST_IMAGE_PATH = path.resolve(
@@ -38,10 +40,83 @@ export const TEST_COORDS = {
 	longitude: -122.676483,
 };
 
-test.use({
-	geolocation: TEST_COORDS,
-	permissions: ["geolocation"],
-});
+/**
+ * Mocks successful browser geolocation before the page loads.
+ * @param page - Playwright page instance.
+ */
+export async function mockCurrentLocationSuccess(
+	page: Page,
+	coords = TEST_COORDS,
+) {
+	await page.addInitScript(
+		(mockCoords: typeof TEST_COORDS) => {
+			const position = {
+				coords: {
+					accuracy: 10,
+					altitude: null,
+					altitudeAccuracy: null,
+					heading: null,
+					latitude: mockCoords.latitude,
+					longitude: mockCoords.longitude,
+					speed: null,
+				},
+				timestamp: Date.now(),
+			};
+
+			Object.defineProperty(navigator, "geolocation", {
+				configurable: true,
+				value: {
+					clearWatch: () => undefined,
+					getCurrentPosition: (success: PositionCallback) => {
+						queueMicrotask(() => success(position as GeolocationPosition));
+					},
+					watchPosition: (success: PositionCallback) => {
+						queueMicrotask(() => success(position as GeolocationPosition));
+						return 1;
+					},
+				},
+			});
+		},
+		coords,
+	);
+}
+
+/**
+ * Mocks failed browser geolocation before the page loads.
+ * @param page - Playwright page instance.
+ * @param message - Error message returned by the browser API.
+ */
+export async function mockCurrentLocationFailure(page: Page, message: string) {
+	await page.addInitScript((mockMessage: string) => {
+		const error = {
+			code: 1,
+			message: mockMessage,
+			PERMISSION_DENIED: 1,
+			POSITION_UNAVAILABLE: 2,
+			TIMEOUT: 3,
+		} as GeolocationPositionError;
+
+		Object.defineProperty(navigator, "geolocation", {
+			configurable: true,
+			value: {
+				clearWatch: () => undefined,
+				getCurrentPosition: (
+					_success: PositionCallback,
+					failure?: PositionErrorCallback | null,
+				) => {
+					queueMicrotask(() => failure?.(error));
+				},
+				watchPosition: (
+					_success: PositionCallback,
+					failure?: PositionErrorCallback | null,
+				) => {
+					queueMicrotask(() => failure?.(error));
+					return 1;
+				},
+			},
+		});
+	}, message);
+}
 
 /**
  * Returns the wizard progressbar locator.

--- a/tests/wizard/shared.ts
+++ b/tests/wizard/shared.ts
@@ -41,77 +41,20 @@ export const TEST_COORDS = {
 };
 
 /**
- * Mocks successful browser geolocation before the page loads.
- * @param page - Playwright page instance.
- */
-export async function mockCurrentLocationSuccess(
-	page: Page,
-	coords = TEST_COORDS,
-) {
-	await page.addInitScript(
-		(mockCoords: typeof TEST_COORDS) => {
-			const position = {
-				coords: {
-					accuracy: 10,
-					altitude: null,
-					altitudeAccuracy: null,
-					heading: null,
-					latitude: mockCoords.latitude,
-					longitude: mockCoords.longitude,
-					speed: null,
-				},
-				timestamp: Date.now(),
-			};
-
-			Object.defineProperty(navigator, "geolocation", {
-				configurable: true,
-				value: {
-					clearWatch: () => undefined,
-					getCurrentPosition: (success: PositionCallback) => {
-						queueMicrotask(() => success(position as GeolocationPosition));
-					},
-					watchPosition: (success: PositionCallback) => {
-						queueMicrotask(() => success(position as GeolocationPosition));
-						return 1;
-					},
-				},
-			});
-		},
-		coords,
-	);
-}
-
-/**
  * Mocks failed browser geolocation before the page loads.
  * @param page - Playwright page instance.
  * @param message - Error message returned by the browser API.
  */
 export async function mockCurrentLocationFailure(page: Page, message: string) {
 	await page.addInitScript((mockMessage: string) => {
-		const error = {
-			code: 1,
-			message: mockMessage,
-			PERMISSION_DENIED: 1,
-			POSITION_UNAVAILABLE: 2,
-			TIMEOUT: 3,
-		} as GeolocationPositionError;
-
 		Object.defineProperty(navigator, "geolocation", {
 			configurable: true,
 			value: {
-				clearWatch: () => undefined,
 				getCurrentPosition: (
-					_success: PositionCallback,
-					failure?: PositionErrorCallback | null,
+					_success: () => void,
+					failure?: (error: { code: number; message: string }) => void,
 				) => {
-					queueMicrotask(() => failure?.(error));
-				},
-				watchPosition: (
-					_success: PositionCallback,
-					failure?: PositionErrorCallback | null,
-				) => {
-					queueMicrotask(() => failure?.(error));
-					return 1;
+					queueMicrotask(() => failure?.({ code: 1, message: mockMessage }));
 				},
 			},
 		});


### PR DESCRIPTION
## Description

Updates the Playwright CI setup so browser installation no longer hangs on the affected Playwright version, and keeps geolocation-related wizard tests deterministic without relying on browser-specific permission behavior.

Related to #56

## Checklist

- [x] I have reviewed my code and made sure it meets the project's coding standards and followed the contributing guide.
- [x] I have tested my code thoroughly (if needed) to ensure it works as expected.
- [x] I have documented my code (if needed) in the README.md.
- [x] I have checked that this PR doesn't introduce any accessibility issues.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Other (performance, refactoring, documentation, dependency, configuration, security)