### PR TITLE
Replace inline template js with shared handlers

### DIFF
--- a/oregoninvasiveshotline/pages/templates/pages/delete.html
+++ b/oregoninvasiveshotline/pages/templates/pages/delete.html
@@ -8,8 +8,8 @@
     <hr />
     <form method="post" id="delete-form">
         {% csrf_token %}
-        <button class="btn btn-default" onclick="window.history.go(-1); return false">Cancel</button>
-        <button type="submit" name="finish" class="pull-right btn btn-danger" onclick="return confirm('Click OK if you are really sure')">Permanently Delete this Page</button>
+        <button type="button" class="btn btn-default" data-history-back>Cancel</button>
+        <button type="submit" name="finish" class="pull-right btn btn-danger" data-confirm="Click OK if you are really sure">Permanently Delete this Page</button>
     </form>
 </div>
 {% endblock %}

--- a/oregoninvasiveshotline/static/js/main.js
+++ b/oregoninvasiveshotline/static/js/main.js
@@ -44,6 +44,61 @@ $(document).ready(function(){
     $('.nav-tabs a:first, .nav-tabs a[href="' + Cookies.get('tab') + '"]').click();
 });
 
+/**
+ * Handles CSP-safe click actions declared with data attributes.
+ *
+ * @param {MouseEvent} event
+ */
+function handleTemplateActionClick(event) {
+    const target = event.target;
+
+    if (!(target instanceof Element)) {
+        return;
+    }
+
+    const historyBack = target.closest("[data-history-back]");
+    if (historyBack) {
+        event.preventDefault();
+        window.history.go(-1);
+        return;
+    }
+
+    const confirmAction = target.closest("[data-confirm]");
+    if (confirmAction) {
+        const message = confirmAction.getAttribute("data-confirm");
+        if (message && !window.confirm(message)) {
+            event.preventDefault();
+        }
+    }
+}
+
+/**
+ * Handles multiple-checkbox group toggles declared by templates.
+ *
+ * @param {Event} event
+ */
+function handleTemplateActionChange(event) {
+    const target = event.target;
+
+    if (!(target instanceof HTMLInputElement) || !target.matches("[data-check-all]")) {
+        return;
+    }
+
+    const checkboxGroup = target.closest(".multiple-checkbox");
+    if (!checkboxGroup) {
+        return;
+    }
+
+    checkboxGroup.querySelectorAll('input[type="checkbox"]:not([data-check-all])').forEach(function(input) {
+        if (input instanceof HTMLInputElement) {
+            input.checked = target.checked;
+        }
+    });
+}
+
+document.addEventListener("click", handleTemplateActionClick);
+document.addEventListener("change", handleTemplateActionChange);
+
 /* This exists solely to avoid duplicating the icon dimension information
  * everywhere. If you are to change this make sure you update
  * `oregoninvasiveshotline/reports/views.py:icon`

--- a/oregoninvasiveshotline/templates/bootstrapform/field.html
+++ b/oregoninvasiveshotline/templates/bootstrapform/field.html
@@ -64,7 +64,7 @@
             <div class="checkbox multiple-checkbox">
         {% endif %}
             {% if field|is_multiple_checkbox %}
-                <label id='check-all-{{ field.auto_id }}' class="check-all" onclick="$(this).parent().find('input').prop('checked', $(this).find('input').prop('checked'))"><input type="checkbox" value="check-all" /> Check all</label>
+                <label id='check-all-{{ field.auto_id }}' class="check-all"><input type="checkbox" value="check-all" data-check-all /> Check all</label>
             {% endif %}
             {{ field }}
 

--- a/oregoninvasiveshotline/templates/delete.html
+++ b/oregoninvasiveshotline/templates/delete.html
@@ -40,11 +40,11 @@
         <div>
             <form method="post" class="form-horizontal">
                 {% csrf_token %}
-                <button class="btn btn-default" onclick="window.history.go(-1); return false">
+                <button type="button" class="btn btn-default" data-history-back>
                     Cancel
                 </button>
                 <button type="submit" name="finish" class="pull-right btn btn-danger"
-                        onclick="return confirm('Click OK if you are really sure')">
+                        data-confirm="Click OK if you are really sure">
                         Permanently Delete {{ object|model_name }} and All Related Objects
                 </button>
             </form>

--- a/oregoninvasiveshotline/templates/notifications/create.html
+++ b/oregoninvasiveshotline/templates/notifications/create.html
@@ -15,6 +15,6 @@
             {% bootstrap_field form.user %}
         {% endif %}
         {% bootstrap_button button_type="submit" content="Submit" class="btn btn-primary" %}
-        <a href="#" class="btn btn-default" data-history-back>Back</a>
+        <button type="button" class="btn btn-default" data-history-back>Back</button>
     </form>
 {% endblock %}

--- a/oregoninvasiveshotline/templates/notifications/create.html
+++ b/oregoninvasiveshotline/templates/notifications/create.html
@@ -15,6 +15,6 @@
             {% bootstrap_field form.user %}
         {% endif %}
         {% bootstrap_button button_type="submit" content="Submit" class="btn btn-primary" %}
-        <a href="javascript:window.history.go(-1)" class="btn btn-default">Back</a>
+        <a href="#" class="btn btn-default" data-history-back>Back</a>
     </form>
 {% endblock %}

--- a/oregoninvasiveshotline/templates/notifications/edit.html
+++ b/oregoninvasiveshotline/templates/notifications/edit.html
@@ -10,6 +10,6 @@
         {% bootstrap_field form.name %}
         {% bootstrap_field form.query %}
         <input type="submit" name="submit" value="Submit" class="btn btn-primary"/>
-        <a href="#" class="btn btn-default" data-history-back>Back</a>
+        <button type="button" class="btn btn-default" data-history-back>Back</button>
     </form>
 {% endblock %}

--- a/oregoninvasiveshotline/templates/notifications/edit.html
+++ b/oregoninvasiveshotline/templates/notifications/edit.html
@@ -10,6 +10,6 @@
         {% bootstrap_field form.name %}
         {% bootstrap_field form.query %}
         <input type="submit" name="submit" value="Submit" class="btn btn-primary"/>
-        <a href="javascript:window.history.go(-1)" class="btn btn-default">Back</a>
+        <a href="#" class="btn btn-default" data-history-back>Back</a>
     </form>
 {% endblock %}

--- a/oregoninvasiveshotline/templates/notifications/list.html
+++ b/oregoninvasiveshotline/templates/notifications/list.html
@@ -15,7 +15,7 @@
                     <tr>
                         <th>
                             {% if form.subscriptions %}
-                                <button class="btn btn-danger btn-xs" name="Delete-Selected" type="submit" Onclick="return confirm('Are you sure you want to delete this search? This action cannot be undone!');"><span class="bi bi-trash"></span></button> Delete
+                                <button class="btn btn-danger btn-xs" name="Delete-Selected" type="submit" data-confirm="Are you sure you want to delete this search? This action cannot be undone!"><span class="bi bi-trash"></span></button> Delete
                             {% else %}
                                 Delete
                             {% endif %}

--- a/oregoninvasiveshotline/templates/reports/claim.html
+++ b/oregoninvasiveshotline/templates/reports/claim.html
@@ -8,8 +8,8 @@ Steal Report
     <form method="post">
         {% csrf_token %}
         <p>Are you sure you want to steal this report from {{ report.claimed_by }}?</p>
-        <button class="btn btn-default" onclick="window.history.go(-1); return false">Cancel</button>
-        <button type="submit" name="steal" class="btn btn-danger" onclick="return confirm('Click OK if you are really sure')">Steal this report</button>
+        <button type="button" class="btn btn-default" data-history-back>Cancel</button>
+        <button type="submit" name="steal" class="btn btn-danger" data-confirm="Click OK if you are really sure">Steal this report</button>
     </form>
 </div>
 {% endblock %}

--- a/oregoninvasiveshotline/templates/reports/unclaim.html
+++ b/oregoninvasiveshotline/templates/reports/unclaim.html
@@ -8,8 +8,8 @@ Unclaim Report
     <form method="post">
         {% csrf_token %}
         <p>Are you sure you want to unclaim this report?</p>
-        <button class="btn btn-default" onclick="window.history.go(-1); return false">Cancel</button>
-        <button type="submit" name="steal" class="btn btn-danger" onclick="return confirm('Click OK if you are really sure')">Unclaim this report</button>
+        <button type="button" class="btn btn-default" data-history-back>Cancel</button>
+        <button type="submit" name="steal" class="btn btn-danger" data-confirm="Click OK if you are really sure">Unclaim this report</button>
     </form>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
Currently, there are a decent number of instances where something like `onclick="return confirm('Click OK if you are really sure')">` is used. Because we added CSP headers that don't allow `unsafe-inline` (and also because inline js is bad practice), we are replacing these with a data tag that relies on js in the main.js file to submit. This PR also adds `type="button"` to the cancel buttons so that the button will act as an actual button rather than a submission button for users without js enabled.

It may be worth adding regression tests for this though? Howerver we really don't have any UI testing for anything besides the react app. Mark needs to decide this one.

Fixes [AB#4519](https://osu-cass.visualstudio.com/5e947304-3b40-453c-9c37-0635483f8d6d/_workitems/edit/4519)

## Checklist

- [x] I have reviewed my code and made sure it meets the project's coding standards and followed the contributing guide.
- [x] I have tested my code thoroughly (if needed) to ensure it works as expected.
- [x] I have documented my code (if needed) in the README.md.
- [x] I have checked that this PR doesn't introduce any accessibility issues.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other (performance, refactoring, documentation, dependency, configuration, security)
<!-- If database changes are included, please describe them: -->