### PR TITLE
Convert report images to WebP server-side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ db.sql
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+
+/dashboard-demo

--- a/oregoninvasiveshotline/reports/forms.py
+++ b/oregoninvasiveshotline/reports/forms.py
@@ -422,7 +422,7 @@ class NewReportForm(forms.Form):
         except ImageConversionError as error:
             raise forms.ValidationError(
                 "One or more images could not be processed. "
-                "Please upload JPG, PNG, or WebP images."
+                "Please upload valid image files."
             ) from error
 
         # NOTE: If the user doesn't exist, a new inactive account is

--- a/oregoninvasiveshotline/reports/forms.py
+++ b/oregoninvasiveshotline/reports/forms.py
@@ -2,14 +2,13 @@ from collections import namedtuple
 from typing import Any, List, cast
 
 from django.contrib.gis.geos import Point
-from django.core.exceptions import SuspiciousFileOperation
 from django.core.files.uploadedfile import UploadedFile
 from django.core.validators import validate_email
 from django.db import transaction
 from django.db.models import Q
 from django import forms
 
-from oregoninvasiveshotline.utils.images import is_webp
+from oregoninvasiveshotline.utils.images import ImageConversionError, get_webp_image
 from oregoninvasiveshotline.utils.search import SearchForm
 from oregoninvasiveshotline.comments.models import Comment
 from oregoninvasiveshotline.counties.models import County
@@ -418,6 +417,14 @@ class NewReportForm(forms.Form):
         """
         if images and images.__len__() > 10:
             raise forms.ValidationError("You can only upload up to 10 images.")
+        try:
+            webp_images = [get_webp_image(image_file) for image_file in images or []]
+        except ImageConversionError as error:
+            raise forms.ValidationError(
+                "One or more images could not be processed. "
+                "Please upload JPG, PNG, or WebP images."
+            ) from error
+
         # NOTE: If the user doesn't exist, a new inactive account is
         #       automatically created here, which seems to me like a
         #       tremendously bad idea (still trying to work out how to
@@ -449,11 +456,7 @@ class NewReportForm(forms.Form):
         report.save()
 
         # Save uploaded images attached to this report.
-        for i, image_file in enumerate(images or []):
-            if not is_webp(image_file):
-                # All submitted images MUST be of type webp
-                # This conversion is done on the client and if it isn't, then the user is an attacker
-                raise SuspiciousFileOperation("Images must be of type webp.")
+        for i, image_file in enumerate(webp_images):
             caption = (captions[i] if captions and i < len(captions) else '') or ''
             Image.objects.create(
                 image=image_file,

--- a/oregoninvasiveshotline/reports/tests.py
+++ b/oregoninvasiveshotline/reports/tests.py
@@ -7,6 +7,7 @@ import io
 import os
 import tempfile
 from datetime import timedelta
+from typing import cast
 from unittest.mock import Mock, patch
 
 from django.utils import timezone
@@ -883,7 +884,8 @@ class NewReportFormTest(TransactionTestCase):
             self.assertTrue(saved_image.image.name.endswith(".webp"))
             with PILImage.open(saved_image.image.path) as img:
                 self.assertEqual(img.format, "WEBP")
-                self.assertEqual(img.convert("RGBA").getpixel((0, 0))[3], 0)
+                pixel = cast(tuple[int, int, int, int], img.convert("RGBA").getpixel((0, 0)))
+                self.assertEqual(pixel[3], 0)
 
     def test_save_raises_validation_error_when_image_conversion_fails(self):
         """Ensure conversion failures surface as validation errors."""

--- a/oregoninvasiveshotline/reports/tests.py
+++ b/oregoninvasiveshotline/reports/tests.py
@@ -5,21 +5,23 @@ import json
 import csv
 import io
 import os
+import tempfile
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
 from django.utils import timezone
 from django.conf import settings
 from django.core import mail
-from django.core.exceptions import NON_FIELD_ERRORS
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.contrib.gis.geos import Point
 from django.db.models.signals import post_save
 from django.db import transaction
 from django.urls import reverse
-from django.test import TestCase, TransactionTestCase
+from django.test import TestCase, TransactionTestCase, override_settings
 
 from model_bakery.baker import make, prepare
+from PIL import Image as PILImage
 
 from oregoninvasiveshotline.utils.test.user import UserMixin
 from oregoninvasiveshotline.comments.forms import CommentForm
@@ -768,6 +770,41 @@ class ReportFormTest(TransactionTestCase, UserMixin):
 
 class NewReportFormTest(TransactionTestCase):
 
+    def _get_valid_form_data(self) -> dict[str, object]:
+        """Return valid report wizard form data."""
+        category = make(Category)
+        return {
+            "find_description": "Found near trail edge",
+            "category": category.pk,
+            "location_description": "Near mile marker 3",
+            "latitude": 44.0481,
+            "longitude": -123.0906,
+            "email": "foo@example.com",
+            "first_name": "Foo",
+            "last_name": "Bar",
+        }
+
+    def _make_uploaded_image(
+        self,
+        file_name: str = "test.png",
+        image_format: str = "PNG",
+        mode: str = "RGB",
+        color: tuple[int, ...] = (255, 0, 0),
+    ) -> InMemoryUploadedFile:
+        """Return an in-memory uploaded image."""
+        image_data = io.BytesIO()
+        PILImage.new(mode, (2, 2), color).save(image_data, format=image_format)
+        image_size = image_data.tell()
+        image_data.seek(0)
+        return InMemoryUploadedFile(
+            image_data,
+            'image',
+            file_name,
+            f"image/{image_format.lower()}",
+            image_size,
+            None,
+        )
+
     def test_identification_process_not_required(self):
         """Ensure the wizard form validates without an identification process note."""
         category = make(Category)
@@ -824,6 +861,49 @@ class NewReportFormTest(TransactionTestCase):
             "Along roadside ditch",
         )
         self.assertEqual(Comment.objects.get(report=report).body, "Can someone confirm species?")
+
+    def test_save_converts_non_webp_images(self):
+        """Ensure non-WebP uploads are saved as WebP files."""
+        form = NewReportForm(self._get_valid_form_data())
+        self.assertTrue(form.is_valid())
+        uploaded_image = self._make_uploaded_image(
+            mode="RGBA",
+            color=(255, 0, 0, 0),
+        )
+
+        with (
+            tempfile.TemporaryDirectory() as media_root,
+            override_settings(MEDIA_ROOT=media_root),
+            patch("oregoninvasiveshotline.reports.forms.notify_report_submission.delay"),
+            patch("oregoninvasiveshotline.reports.forms.notify_report_subscribers.delay"),
+        ):
+            report = form.save(images=[uploaded_image])
+            saved_image = Image.objects.get(report=report)
+
+            self.assertTrue(saved_image.image.name.endswith(".webp"))
+            with PILImage.open(saved_image.image.path) as img:
+                self.assertEqual(img.format, "WEBP")
+                self.assertEqual(img.convert("RGBA").getpixel((0, 0))[3], 0)
+
+    def test_save_raises_validation_error_when_image_conversion_fails(self):
+        """Ensure conversion failures surface as validation errors."""
+        form = NewReportForm(self._get_valid_form_data())
+        self.assertTrue(form.is_valid())
+        image_data = io.BytesIO(b"not an image")
+        uploaded_image = InMemoryUploadedFile(
+            image_data,
+            'image',
+            'test.jpg',
+            'image/jpeg',
+            len(image_data.getvalue()),
+            None,
+        )
+
+        with self.assertRaisesMessage(
+            ValidationError,
+            "One or more images could not be processed. Please upload valid image files.",
+        ):
+            form.save(images=[uploaded_image])
 
 
 class ManagementFormTest(SuppressPostSaveMixin, TestCase):

--- a/oregoninvasiveshotline/utils/images.py
+++ b/oregoninvasiveshotline/utils/images.py
@@ -52,52 +52,31 @@ def generate_thumbnail(input_path, output_path, width, height):
     return True
 
 
-def get_webp_filename(file_name: str) -> str:
-    """Return a WebP filename based on an uploaded file name."""
-    stem = Path(file_name).stem or "image"
-    return f"{stem}.webp"
-
-
-def is_webp(image_file: UploadedFile) -> bool:
-    """Check whether an uploaded image file is a valid WebP image.
-
-    Resets the file pointer before and after inspection so the file can still
-    be read later by Django/storage.
+def get_webp_image(image_file: UploadedFile) -> UploadedFile | ContentFile:
+    """Return an uploaded image as WebP, converting when necessary.
 
     Args:
-        image_file: Uploaded image file to inspect.
+        image_file: Uploaded image file to inspect and optionally convert.
 
     Returns:
-        bool: True if the file is a valid WebP image, otherwise False.
+        UploadedFile | ContentFile: Original WebP upload or converted WebP file.
+
+    Raises:
+        ImageConversionError: If the upload cannot be read or converted.
     """
     image_file.seek(0)
 
     try:
         with Image.open(image_file) as img:
-            if img.format != WEBP_FORMAT:
-                return False
-    except UnidentifiedImageError:
-        return False
-    finally:
-        image_file.seek(0)
+            if img.format == WEBP_FORMAT:
+                return image_file
 
-    return True
-
-
-def get_webp_image(image_file: UploadedFile) -> UploadedFile | ContentFile:
-    """Return an uploaded image as WebP, converting when necessary."""
-    if is_webp(image_file):
-        return image_file
-
-    image_file.seek(0)
-
-    try:
-        with Image.open(image_file) as img:
-            img = ImageOps.exif_transpose(img)
             output = BytesIO()
-            has_alpha = img.mode in {"RGBA", "LA"} or "transparency" in img.info
-            img = img.convert("RGBA" if has_alpha else "RGB")
-            img.save(output, format=WEBP_FORMAT, quality=80, method=6)
+            ImageOps.exif_transpose(img).convert("RGB").save(
+                output,
+                format=WEBP_FORMAT,
+                quality=85,
+            )
     except (OSError, UnidentifiedImageError) as error:
         raise ImageConversionError("Image could not be converted to WebP.") from error
     finally:
@@ -105,5 +84,5 @@ def get_webp_image(image_file: UploadedFile) -> UploadedFile | ContentFile:
 
     return ContentFile(
         output.getvalue(),
-        name=get_webp_filename(image_file.name),
+        name=f"{Path(image_file.name).stem or 'image'}.webp",
     )

--- a/oregoninvasiveshotline/utils/images.py
+++ b/oregoninvasiveshotline/utils/images.py
@@ -14,6 +14,11 @@ class ImageConversionError(Exception):
     """Raised when an uploaded image cannot be converted."""
 
 
+def _get_webp_mode(img: Image.Image) -> str:
+    """Return the image mode to use before saving as WebP."""
+    return "RGBA" if "A" in img.getbands() or "transparency" in img.info else "RGB"
+
+
 def generate_thumbnail(input_path, output_path, width, height):
     """Generate a thumbnail from the source image.
 
@@ -72,12 +77,13 @@ def get_webp_image(image_file: UploadedFile) -> UploadedFile | ContentFile:
                 return image_file
 
             output = BytesIO()
-            ImageOps.exif_transpose(img).convert("RGB").save(
+            img = ImageOps.exif_transpose(img)
+            img.convert(_get_webp_mode(img)).save(
                 output,
                 format=WEBP_FORMAT,
                 quality=85,
             )
-    except (OSError, UnidentifiedImageError) as error:
+    except (OSError, UnidentifiedImageError, Image.DecompressionBombError) as error:
         raise ImageConversionError("Image could not be converted to WebP.") from error
     finally:
         image_file.seek(0)

--- a/oregoninvasiveshotline/utils/images.py
+++ b/oregoninvasiveshotline/utils/images.py
@@ -1,8 +1,17 @@
 import logging
-from PIL import Image, UnidentifiedImageError
+from io import BytesIO
+from pathlib import Path
+
+from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import UploadedFile
+from PIL import Image, ImageOps, UnidentifiedImageError
 
 log = logging.getLogger(__name__)
+WEBP_FORMAT = "WEBP"
+
+
+class ImageConversionError(Exception):
+    """Raised when an uploaded image cannot be converted."""
 
 
 def generate_thumbnail(input_path, output_path, width, height):
@@ -43,7 +52,13 @@ def generate_thumbnail(input_path, output_path, width, height):
     return True
 
 
-def is_webp(image_file: UploadedFile):
+def get_webp_filename(file_name: str) -> str:
+    """Return a WebP filename based on an uploaded file name."""
+    stem = Path(file_name).stem or "image"
+    return f"{stem}.webp"
+
+
+def is_webp(image_file: UploadedFile) -> bool:
     """Check whether an uploaded image file is a valid WebP image.
 
     Resets the file pointer before and after inspection so the file can still
@@ -56,14 +71,39 @@ def is_webp(image_file: UploadedFile):
         bool: True if the file is a valid WebP image, otherwise False.
     """
     image_file.seek(0)
-    
+
     try:
         with Image.open(image_file) as img:
-            if img.format != "WEBP":
+            if img.format != WEBP_FORMAT:
                 return False
     except UnidentifiedImageError:
         return False
     finally:
         image_file.seek(0)
-        
+
     return True
+
+
+def get_webp_image(image_file: UploadedFile) -> UploadedFile | ContentFile:
+    """Return an uploaded image as WebP, converting when necessary."""
+    if is_webp(image_file):
+        return image_file
+
+    image_file.seek(0)
+
+    try:
+        with Image.open(image_file) as img:
+            img = ImageOps.exif_transpose(img)
+            output = BytesIO()
+            has_alpha = img.mode in {"RGBA", "LA"} or "transparency" in img.info
+            img = img.convert("RGBA" if has_alpha else "RGB")
+            img.save(output, format=WEBP_FORMAT, quality=80, method=6)
+    except (OSError, UnidentifiedImageError) as error:
+        raise ImageConversionError("Image could not be converted to WebP.") from error
+    finally:
+        image_file.seek(0)
+
+    return ContentFile(
+        output.getvalue(),
+        name=get_webp_filename(image_file.name),
+    )


### PR DESCRIPTION
## Summary
- Convert non-WebP report images to WebP on the server before saving them.
- Keep existing WebP uploads unchanged and preserve the current client-side resize behavior.
- Save converted uploads with a `.webp` extension and show a validation error when conversion fails.

Fixes [AB#4577](https://osu-cass.visualstudio.com/5e947304-3b40-453c-9c37-0635483f8d6d/_workitems/edit/4577)

## Checklist

- [x] I have reviewed my code and made sure it meets the project's coding standards and followed the contributing guide.
- [x] I have tested my code thoroughly (if needed) to ensure it works as expected.
- [x] I have documented my code (if needed) in the README.md.
- [x] I have checked that this PR doesn't introduce any accessibility issues.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other (performance, refactoring, documentation, dependency, configuration, security)
<!-- If database changes are included, please describe them: -->