### PR TITLE
fix: constrain location picker column width

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ about the species that was reported.
 
 Packages are managed with a jsDelivr script link in `templates/base.html`.
 
+## Deployment Links
+
+- Staging: <https://staging.oregoninvasiveshotline.org/>
+- Production: <https://oregoninvasiveshotline.org/>
+
 ## Getting started
 
 Ensure that you have Docker and Docker Compose installed in your host's environment.

--- a/frontend/src/components/wizard/locationMap.tsx
+++ b/frontend/src/components/wizard/locationMap.tsx
@@ -216,7 +216,10 @@ export default function LocationMap({
 	];
 
 	return (
-		<div className="d-grid gap-2">
+		<div
+			className="d-grid gap-2"
+			style={{ gridTemplateColumns: "minmax(0, 1fr)" }}
+		>
 			{/* Location mode toggle group. */}
 			<div>
 				<p


### PR DESCRIPTION
Resolves [AB#4658](https://osu-cass.visualstudio.com/Invasive%20Species%20Hotline/_workitems/edit/4658)
Resolves [AB#4568](https://osu-cass.visualstudio.com/Invasive%20Species%20Hotline/_workitems/edit/4568)

## Summary
Previously the report location picker in `reports/create-new` did not constrain the width of columns and could overflow beyond its container in Search mode due to the large `PlaceAutoCompleteElement`. 
This was fixed by adding  `gridTemplateColumns: "minmax(0, 1fr)"` which constrains the location picker columns to the container's width.

Also added a new section to the `README.md` with links to staging and production.