### PR TITLE
Feat/new old report form switcher

### DIFF
--- a/frontend/src/components/wizard/announcementBanner.tsx
+++ b/frontend/src/components/wizard/announcementBanner.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+interface AnnouncementBannerProps {
+  /** Content to include in the banner */
+  children: ReactNode;
+}
+
+/** Displays a compact informational announcement. */
+export default function AnnouncementBanner({
+	children,
+}: AnnouncementBannerProps) {
+	return <div className="alert alert-info mb-3 px-3 py-2">{children}</div>;
+}

--- a/frontend/src/features/reportWizard.tsx
+++ b/frontend/src/features/reportWizard.tsx
@@ -7,6 +7,7 @@ import {
 	Steps,
 	type WizardFormData,
 } from "../components/wizard/fields";
+import AnnouncementBanner from "../components/wizard/announcementBanner";
 import StepFour from "../components/wizard/steps/four";
 import StepOne from "../components/wizard/steps/one";
 import StepThree from "../components/wizard/steps/three";
@@ -58,6 +59,9 @@ export default function FormWizard(props: FormWizardProps) {
 						<h1 className="h3 mb-2 text-center text-white">
 							Report an Invader
 						</h1>
+						<AnnouncementBanner>
+							Return to the old report page <a href="/reports/create">here!</a>
+						</AnnouncementBanner>
 						<div className="card rounded-4 shadow-md">
 							<div className="card-body p-3 p-md-4">
 								<div

--- a/frontend/src/features/reportWizard.tsx
+++ b/frontend/src/features/reportWizard.tsx
@@ -60,7 +60,7 @@ export default function FormWizard(props: FormWizardProps) {
 							Report an Invader
 						</h1>
 						<AnnouncementBanner>
-							Return to the old report page <a href="/reports/create">here!</a>
+						<a href="/reports/create">Click here to use the Hotline classic reporting tool.</a>
 						</AnnouncementBanner>
 						<div className="card rounded-4 shadow-md">
 							<div className="card-body p-3 p-md-4">

--- a/oregoninvasiveshotline/templates/reports/create.html
+++ b/oregoninvasiveshotline/templates/reports/create.html
@@ -7,6 +7,10 @@
 Report an Invader
 {% endblock %}
 {% block content %}
+<div class="alert alert-info mb-3 px-3 py-2">
+    Try our new report page <a href="{% url 'reports-create-new' %}">here!</a>
+</div>
+
 <h3>Report an Invader</h3>
 
 <p>Use this form to report a potential invasive species you've found in Oregon or to request help in identifying an unknown species. The information you provide will assist invasive species experts in positively identifying your find. Please try to be as complete and detailed as possible.</p>

--- a/oregoninvasiveshotline/templates/reports/create.html
+++ b/oregoninvasiveshotline/templates/reports/create.html
@@ -8,7 +8,7 @@ Report an Invader
 {% endblock %}
 {% block content %}
 <div class="alert alert-info mb-3 px-3 py-2">
-    Try our new report page <a href="{% url 'reports-create-new' %}">here!</a>
+    <a href="{% url 'reports-create-new' %}">Click here to use the new Hotline reporting tool.</a>
 </div>
 
 <h3>Report an Invader</h3>


### PR DESCRIPTION
Added a link between the new and old report form.
Created a reusable component to be like the alert banner in the django pages.
Resolves [AB#4657](https://osu-cass.visualstudio.com/Invasive%20Species%20Hotline/_workitems/edit/4657)