### PR TITLE
fix: handle invalid password reset link

### DIFF
--- a/oregoninvasiveshotline/templates/registration/password_reset_confirm.html
+++ b/oregoninvasiveshotline/templates/registration/password_reset_confirm.html
@@ -14,7 +14,7 @@ Set Password
     </form>
 {% else %}
     <h2>Password reset unsuccessful</h2>
-    <p>The password reset link is invalid, expired.</p>
+    <p>The password reset link is invalid or has expired.</p>
     <p><a href="{% url 'password_reset' %}">Request a new password reset</a></p>
 {% endif %}
 {% endblock %}

--- a/oregoninvasiveshotline/templates/registration/password_reset_confirm.html
+++ b/oregoninvasiveshotline/templates/registration/password_reset_confirm.html
@@ -5,10 +5,16 @@ Set Password
 {% block content %}
 
 {% load django_bootstrap5 %}
-<h2>Set your new password</h2>
-<form action="" method="post">
-    {% csrf_token %}
-    {% bootstrap_form form %}
-    {% bootstrap_button button_type="submit" content="Submit" class="btn btn-primary" %}
-</form>
+{% if validlink %}
+    <h2>Set your new password</h2>
+    <form action="" method="post">
+        {% csrf_token %}
+        {% bootstrap_form form %}
+        {% bootstrap_button button_type="submit" content="Submit" class="btn btn-primary" %}
+    </form>
+{% else %}
+    <h2>Password reset unsuccessful</h2>
+    <p>The password reset link is invalid, expired.</p>
+    <p><a href="{% url 'password_reset' %}">Request a new password reset</a></p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
Resolves [AB#4719](https://osu-cass.visualstudio.com/Invasive%20Species%20Hotline/_workitems/edit/4719)

Django's PasswordResetConfirmView renders the reset confirmation template with validlink=False and form=None when a reset link is invalid or expired. The template always passed this invalid form to django_bootstrap5, which raised a TypeError.

This is resolved by wrapping the form post method in `password_reset_confirm.html` with an `{% if validlink %}` and returning a password reset unsuccessful body when validlink=False.

Instead of getting a 500 error, the user will now see this. This fits better than returning 404 because the pattern does match a real endpoint.

<img width="1554" height="524" alt="9706cfd73c9fc0d2949eef4c6225b28ba963a14af48d9944954b108eb874acc3" src="https://github.com/user-attachments/assets/85ac2403-10d4-47ae-87c6-17a70ddb8912" />


I am open to changing the wording of this if needed to be more accurate.
