### PR TITLE
fix: move image alert banners above upload instructions

### DIFF
--- a/oregoninvasiveshotline/templates/_images.html
+++ b/oregoninvasiveshotline/templates/_images.html
@@ -2,6 +2,14 @@
 
 <fieldset id="images">
     <legend>Images</legend>
+    {% if show_image_alerts %}
+        <p class="alert alert-info">
+            <strong>We strongly encourage you to submit a photo with your report. Reports without photos make it extremely difficult for Hotline managers to handle your report.</strong>
+        </p>
+        <p class="alert alert-info">
+            <strong>Emerald Ash Borer reports must include a photo of the insect itself or signs/symptoms of the infested tree for identification.</strong>
+        </p>
+    {% endif %}
     <p>
       <em>
         To add photos, click the button below and browse for the image on your computer.
@@ -11,14 +19,6 @@
         licensing guidelines.
       </em>
     </p>
-    {% if show_image_alerts %}
-        <p class="alert alert-info">
-            <strong>We strongly encourage you to submit a photo with your report. Reports without photos make it extremely difficult for Hotline managers to handle your report.</strong>
-        </p>
-        <p class="alert alert-info">
-            <strong>Emerald Ash Borer reports must include a photo of the insect itself or signs/symptoms of the infested tree for identification.</strong>
-        </p>
-    {% endif %}
     <div class="formset">
         {{ formset.management_form }}
         <!-- the first form yielded is the empty form. We use that as a template for the JS, so make it hidden -->


### PR DESCRIPTION
Resolves [AB#4721](https://osu-cass.visualstudio.com/Invasive%20Species%20Hotline/_workitems/edit/4721)
Before:
<img width="1497" height="680" alt="c1d532e8c2f8a4694fcb7133c86221e67b6e93c481fc276797279b99363d50d7" src="https://github.com/user-attachments/assets/e6adcf48-33cf-4389-97d7-9cef5550c6ce" />


After:
<img width="1442" height="306" alt="a547a55782112613fd399ecada7ecece9debe211e3b14b9a750ece4274ee31ff" src="https://github.com/user-attachments/assets/74eae404-e92f-4359-92a8-340c1de4c0d5" />
