### PR TITLE
fix: use valid static asset on comment edit page

### DIFF
--- a/oregoninvasiveshotline/templates/comments/edit.html
+++ b/oregoninvasiveshotline/templates/comments/edit.html
@@ -20,5 +20,5 @@
 
 {% block js %}
     {{ block.super }}
-    <script nonce="{{csp_nonce}}" src="{% static 'js/ss' %}"></script>
+    <script nonce="{{csp_nonce}}" src="{% static 'js/img.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Problem

Attempting to edit a comment on staging resulted in a 500 Server Error.

The comment edit template referenced a missing static asset, `js/ss`. In staging, manifest static storage validates static asset paths during template rendering, which caused:

`ValueError: Missing staticfiles manifest entry for 'js/ss'`

Local dev server did not reproduce this because it does not validate the static path the same way.

## Fix

Update the comment edit template to load the existing image form script `js/img.js` instead of the missing `js/ss` asset.

## Verification

- Reproduced the missing manifest entry locally with `DEBUG=false` to have the same behavior as staging.
- Confirmed `js/img.js` resolves through the staticfiles manifest: `/static/js/img.757141c8c962.js`
- Confirmed the Sentry error matches the bad `js/ss` static lookup.
<img width="1275" height="703" alt="0e528d5c38fac1d6704a4ffba4ce81f7af6f6c98b7bc00534ce75f2b5b4c0b18" src="https://github.com/user-attachments/assets/645bfffa-80a8-44db-b371-7c304c35608e" />


Resolves [AB#4728](https://osu-cass.visualstudio.com/Invasive%20Species%20Hotline/_workitems/edit/4728)