### PR TITLE
fix: do not override active user identity on comment edit

### DIFF
--- a/oregoninvasiveshotline/comments/perms.py
+++ b/oregoninvasiveshotline/comments/perms.py
@@ -15,6 +15,23 @@ def can_edit_comment(user, comment):
     return user.is_staff or comment.created_by == user
 
 
+def get_comment_editor(request, comment):
+    """Resolve the effective user allowed to edit the comment"""
+    if can_edit_comment(request.user, comment):
+        return request.user
+    report = comment.report
+
+    # Anonymous reporters can edit their own comments
+    if (
+        request.user.is_anonymous
+        and report.pk in request.session.get("report_ids", [])
+        and not report.created_by.is_active
+        and comment.created_by_id == report.created_by_id
+    ):
+        return report.created_by
+    return None
+
+
 @permissions.register(model=Comment)
 def can_delete_comment(user, comment):
     return comment.pk is not None and can_edit_comment(user, comment)

--- a/oregoninvasiveshotline/comments/views.py
+++ b/oregoninvasiveshotline/comments/views.py
@@ -17,7 +17,11 @@ from .perms import can_edit_comment
 def edit(request, comment_id):
     comment = get_object_or_404(Comment, pk=comment_id)
     report = comment.report
-    if report.pk in request.session.get("report_ids", []) and not report.created_by.is_active:
+    if (
+        report.pk in request.session.get("report_ids", []) and
+        not report.created_by.is_active and
+        not request.user.is_active
+    ):
         request.user = report.created_by
 
     if request.user.is_anonymous:

--- a/oregoninvasiveshotline/comments/views.py
+++ b/oregoninvasiveshotline/comments/views.py
@@ -11,30 +11,23 @@ from oregoninvasiveshotline.images.models import Image
 
 from .forms import CommentForm
 from .models import Comment
-from .perms import can_edit_comment
+from .perms import get_comment_editor
 
 
 def edit(request, comment_id):
     comment = get_object_or_404(Comment, pk=comment_id)
-    report = comment.report
-    if (
-        report.pk in request.session.get("report_ids", []) and
-        not report.created_by.is_active and
-        not request.user.is_active
-    ):
-        request.user = report.created_by
 
-    if request.user.is_anonymous:
-        return login_required(lambda request: HttpResponse())(request)
-
-    if not can_edit_comment(request.user, comment):
+    user = get_comment_editor(request, comment)
+    if user is None:
+        if request.user.is_anonymous:
+            return login_required(lambda request: HttpResponse())(request)
         raise PermissionDenied()
 
-    PartialCommentForm = functools.partial(CommentForm, user=request.user, report=comment.report, instance=comment)
+    PartialCommentForm = functools.partial(CommentForm, user=user, report=comment.report, instance=comment)
     if request.POST:
         form = PartialCommentForm(request.POST)
         # ImageFormSet effectively extends BaseImageFormSet but is Any, so we coerce it to the type we want and ignore the type error
-        formset: BaseImageFormSet = ImageFormSet(request.POST, request.FILES, queryset=Image.objects.filter(comment=comment), form_kwargs={'user': request.user})  # pyright: ignore[reportAssignmentType]
+        formset: BaseImageFormSet = ImageFormSet(request.POST, request.FILES, queryset=Image.objects.filter(comment=comment), form_kwargs={'user': user})  # pyright: ignore[reportAssignmentType]
         if form.is_valid() and formset.is_valid():
             form.save()
             formset.save_all(user=comment.created_by, fk=comment)
@@ -43,7 +36,7 @@ def edit(request, comment_id):
     else:
         form = PartialCommentForm()
         # see above comment for ignore reasoning
-        formset: BaseImageFormSet = ImageFormSet(queryset=Image.objects.filter(comment=comment), form_kwargs={'user': request.user})  # pyright: ignore[reportAssignmentType]
+        formset: BaseImageFormSet = ImageFormSet(queryset=Image.objects.filter(comment=comment), form_kwargs={'user': user})  # pyright: ignore[reportAssignmentType]
 
     return render(request, "comments/edit.html", {
         "comment": comment,
@@ -56,7 +49,7 @@ def delete(request, comment_id):
     comment = get_object_or_404(Comment, pk=comment_id)
     report = comment.report
     if request.method == "POST":
-        if can_edit_comment(request.user, comment):
+        if get_comment_editor(request, comment) is not None:
             comment.delete()
             messages.success(request, "Comment Deleted")
         else:


### PR DESCRIPTION
## Problem

Comment edit was overriding `request.user` with the inactive report submitter whenever the current session had that report ID in `session["report_ids"]`.

That broke active manager/admin sessions: after visiting a public reporter auth link, the logged in user could be treated as the inactive reporter and hit `Permission Denied` when editing comments they should be allowed to edit.

## Fix

Extract permission logic into perms.py as helper function `get_comment_editor`. Checks standard permissions first (staff or comment owner), then only falls through to the anonymous reporter branch when those fail. No longer overrides `request.user` in the view. Also much clearer and explicit.

## Validation

Manually verified locally with example data:

- With the fix stashed, manager/admin users hit `Permission Denied` after first opening a public reporter auth link in the same browser session.
- With the fix applied, active manager/admin users retain their expected comment edit permissions.

Resolves [AB#4729](https://osu-cass.visualstudio.com/Invasive%20Species%20Hotline/_workitems/edit/4729)