### PR TITLE
feat: hide PII from non admin and non active

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Packages are managed with a jsDelivr script link in `templates/base.html`.
 ## Deployment Links
 
 - Staging: <https://staging.oregoninvasiveshotline.org/>
+  - Contact staff for the Mailpit link to view emails on staging.
 - Production: <https://oregoninvasiveshotline.org/>
 
 ## Getting started

--- a/oregoninvasiveshotline/reports/perms.py
+++ b/oregoninvasiveshotline/reports/perms.py
@@ -27,6 +27,11 @@ def can_view_private_report(user, report):
         return True
 
 
+@permissions.register(model=Report)
+def can_view_report_submitter_pii(user, report: Report) -> bool:
+    return user.is_authenticated and (user.is_active or user.is_staff)
+
+
 # Ignored the assignment of the decorator as it applies properly at runtime.
 @permissions.register(model=Report)  # pyright: ignore
 def can_adjust_visibility(user, report):

--- a/oregoninvasiveshotline/templates/reports/detail.html
+++ b/oregoninvasiveshotline/templates/reports/detail.html
@@ -35,7 +35,7 @@ Report #{{ report.pk }} - {{ report }}
                     <em>Submitter does not have a specimen</em><br />
                 {% endif %}
 
-                {% if user|can_create_comment:report %}
+                {% if user|can_view_report_submitter_pii:report %}
                     <strong>Submitted by:</strong> {{ report.created_by.first_name }} {{ report.created_by.last_name }} ({{ report.created_by.email }}) {% if report.created_by.phone %}{{ report.created_by.phone }}{% endif %}<br />
                 {% endif %}
 


### PR DESCRIPTION
## Problem

Reporter PII was visible to report creators on the report detail page. This is unsafe because a new anonymous report can be submitted with someone else’s email address, causing it to resolve to that existing user and expose that user’s PII back to the submitter.

## Fix

Restrict reporter PII on the report detail page to admins and managers only. 

Also adds note about emails in staging

Resolves [AB#4737](https://osu-cass.visualstudio.com/Invasive%20Species%20Hotline/_workitems/edit/4737)