### PR TITLE
feat: add character counter to old report form

### DIFF
--- a/oregoninvasiveshotline/static/js/char_counter.js
+++ b/oregoninvasiveshotline/static/js/char_counter.js
@@ -1,0 +1,19 @@
+// Live "used / max" character counter beneath
+// each report-form textarea with a maxlength
+$(document).ready(function () {
+    $('#reports-form textarea[maxlength]').each(function () {
+        var max = $(this).attr('maxlength');
+        var counter = $('<div/>', {'class': 'form-text text-end'});
+        $(this).after(counter);
+
+        var update = function (value) {
+            counter.text(value.length + ' / ' + max);
+        };
+
+        update($(this).val());
+
+        $(this).on('input', function () {
+            update($(this).val());
+        });
+    });
+});

--- a/oregoninvasiveshotline/templates/reports/create.html
+++ b/oregoninvasiveshotline/templates/reports/create.html
@@ -98,6 +98,7 @@ Report an Invader
     <script nonce="{{csp_nonce}}" src="{% static 'js/img.js' %}" async></script>
     <script nonce="{{csp_nonce}}">var category_id_to_species_id = {{ category_id_to_species_id|safe }};</script>
     <script nonce="{{csp_nonce}}" src="{% static 'js/species_selector.js' %}" async></script>
+    <script nonce="{{csp_nonce}}" src="{% static 'js/char_counter.js' %}" async></script>
 
     <script nonce="{{csp_nonce}}">
         function initMap() {


### PR DESCRIPTION
## Summary

Adds character counter beneath the textareas on the old Django report form, matching the existing one from the new React report form.

## Changes

- Add `char_counter.js` 
- Include the script in `reports/create.html`

Resolves [AB#4754](https://osu-cass.visualstudio.com/Invasive%20Species%20Hotline/_workitems/edit/4754)