### PR TITLE
fix: prevent 500 on report image conversion fail

### DIFF
--- a/oregoninvasiveshotline/reports/views.py
+++ b/oregoninvasiveshotline/reports/views.py
@@ -385,7 +385,7 @@ def create_new(request: HttpRequest):
             try:
                 report = form.save(images=images, captions=captions)
             except forms.ValidationError as e:
-                form.add_error("images", e)
+                form.add_error(None, e)
             else:
                 messages.success(request, "Report submitted successfully")
                 request.session.setdefault("report_ids", []).append(report.pk)


### PR DESCRIPTION
Resolves [AB#4802](https://osu-cass.visualstudio.com/Invasive%20Species%20Hotline/_workitems/edit/4802)
## Summary

A 500 error was returned when an uploaded file could not be converted to an image. An example is a text file being renamed to have the `.jpg` extension.

The conversion error was raised as a validation error, but attached to `images`, which is not a declared Django form field, so it raised a different exception that caused a 500 error.

This cannot happen with regular frontend use as it would reject the file. However, a request manually sent to the backend with curl can cause this.

This change records the conversion failure as a non-field form error instead to avoid the vague 500 error. 