### PR TITLE
fix: guard against invalid EXIF GPS coordinates on image upload

### DIFF
--- a/frontend/src/components/forms/images/upload.tsx
+++ b/frontend/src/components/forms/images/upload.tsx
@@ -117,15 +117,16 @@ export default function ImageUpload({
 			await Promise.allSettled(
 				incoming.map(async (file) => {
 					const tags = await ExifReader.load(file, { expanded: true });
-					const lng = tags.gps?.Longitude;
-					const lat = tags.gps?.Latitude;
-					if (lng != null && lat != null) {
-						if (operationVersion !== locationVersion.current) return;
-						imageLocations.set(`${file.name}-${file.lastModified}`, {
-							lat: Number(lat),
-							lng: Number(lng),
-						});
-					}
+
+					/**
+					 * Android may redact EXIF location metadata, resulting in NaN values.
+					 * Missing values also become NaN through Number(undefined).
+					 */
+					const lat = Number(tags.gps?.Latitude);
+					const lng = Number(tags.gps?.Longitude);
+					if (!Number.isFinite(lat) || !Number.isFinite(lng)) return;
+					if (operationVersion !== locationVersion.current) return;
+					imageLocations.set(getImageKey(file), { lat, lng });
 				}),
 			);
 


### PR DESCRIPTION
Resolves [AB#4810](https://osu-cass.visualstudio.com/Invasive%20Species%20Hotline/_workitems/edit/4810)

## Problem

Android phones redact EXIF GPS location, leaving the coordinates present but invalid (`NaN`). The `upload.tsx` code only checked that coordinates existed, not that they were valid, so redacted `NaN` values got stored and passed to Google Maps.

Google Maps then rejects `NaN` coordinates and throws. There are no error boundaries on the frontend, so the exception propagated up and tore down the whole React tree, unmounting the app and leaving just the green Django template background.

## Solution

Validate with `Number.isFinite()` before storing. Still skips missing coordinates like the previous null check, but now also skips redacted `NaN` values. Redacted photos are now ignored instead of crashing the page.
