### PR TITLE
chore(deps): update GitHub Actions runtime dependencies

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -36,7 +36,7 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.branch.outputs.ref }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     format-and-lint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@v7
 
             - name: Install Python
               uses: actions/setup-python@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
             - uses: actions/checkout@v7
 
             - name: Install Python
-              uses: actions/setup-python@v6
+              uses: actions/setup-python@v7
               with:
                   python-version: "3.12"
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -55,7 +55,7 @@ jobs:
         run: npm ci
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/*
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,7 +19,7 @@ jobs:
       GOOGLE_MAP_ID: ${{ secrets.GOOGLE_MAP_ID }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## Summary

- Update `actions/checkout` from v6 to v7 across five workflows.
- Update `actions/setup-python` from v6 to v7.
- Update `actions/setup-node` from v6 to v7.
- Update `actions/cache` from v5 to v6.

This groups Dependabot PRs #85, #86, #88, and #89 so the CI toolchain can be reviewed and exercised as one compatible unit.

## Why

These actions jointly define the repository's CI runtime. Grouping them avoids repeatedly rebasing overlapping workflow changes and lets GitHub validate the final workflow combination.

## Validation

- Workflow-only diff and `git diff --check` passed.
- Compose configuration passed.
- Clean rebuild and force recreation passed.
- Django system check passed.
- Frontend production build passed.
- Backend suite ran all 194 tests and matched the existing baseline: 188 passed and the same six mail-outbox assertion failures.

Actual Actions v7/v6 execution is intentionally left to this draft PR's GitHub Actions runs.
