### PR TITLE
chore(deps): update React family to 19.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"exifreader": "^4.38.1",
 				"jotai": "^2.15.1",
 				"laravel-precognition": "^1.0.2",
-				"react": "^19.2.4",
+				"react": "^19.2.8",
 				"react-dom": "^19.2.4",
 				"sonner": "^2.0.7",
 				"yet-another-react-lightbox": "^3.30.1"
@@ -27,7 +27,7 @@
 				"@playwright/test": "^1.60.0",
 				"@types/google.maps": "^3.58.1",
 				"@types/node": "^25.5.0",
-				"@types/react": "^19.2.14",
+				"@types/react": "^19.2.17",
 				"@types/react-dom": "^19.2.3",
 				"@vitejs/plugin-react": "^6.0.1",
 				"babel-plugin-react-compiler": "^1.0.0",
@@ -1373,9 +1373,9 @@
 			}
 		},
 		"node_modules/@types/react": {
-			"version": "19.2.14",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+			"version": "19.2.17",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+			"integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2513,9 +2513,9 @@
 			}
 		},
 		"node_modules/react": {
-			"version": "19.2.4",
-			"resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-			"integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+			"version": "19.2.8",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+			"integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"jotai": "^2.15.1",
 				"laravel-precognition": "^1.0.2",
 				"react": "^19.2.8",
-				"react-dom": "^19.2.4",
+				"react-dom": "^19.2.8",
 				"sonner": "^2.0.7",
 				"yet-another-react-lightbox": "^3.30.1"
 			},
@@ -2522,15 +2522,15 @@
 			}
 		},
 		"node_modules/react-dom": {
-			"version": "19.2.4",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-			"integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+			"version": "19.2.8",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+			"integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
 			"license": "MIT",
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
 			"peerDependencies": {
-				"react": "^19.2.4"
+				"react": "^19.2.8"
 			}
 		},
 		"node_modules/readdirp": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"exifreader": "^4.38.1",
 		"jotai": "^2.15.1",
 		"laravel-precognition": "^1.0.2",
-		"react": "^19.2.4",
+		"react": "^19.2.8",
 		"react-dom": "^19.2.4",
 		"sonner": "^2.0.7",
 		"yet-another-react-lightbox": "^3.30.1"
@@ -35,7 +35,7 @@
 		"@playwright/test": "^1.60.0",
 		"@types/google.maps": "^3.58.1",
 		"@types/node": "^25.5.0",
-		"@types/react": "^19.2.14",
+		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.1",
 		"babel-plugin-react-compiler": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"jotai": "^2.15.1",
 		"laravel-precognition": "^1.0.2",
 		"react": "^19.2.8",
-		"react-dom": "^19.2.4",
+		"react-dom": "^19.2.8",
 		"sonner": "^2.0.7",
 		"yet-another-react-lightbox": "^3.30.1"
 	},


### PR DESCRIPTION
## Summary

- Update `react` from 19.2.4 to 19.2.8.
- Update `react-dom` from 19.2.4 to 19.2.8.
- Update `@types/react` from 19.2.14 to 19.2.17.

This groups Dependabot PRs #91 and #93 so the React runtime, DOM renderer, and types remain aligned.

## Why

Merging the original PRs independently would temporarily mismatch React and react-dom and repeatedly rewrite the same lockfile.

## Validation

- Clean Docker `npm ci` and lockfile validation passed.
- Installed versions matched the requested versions.
- Production Vite build passed.
- Django system check passed.
- Backend suite matched the existing 194-test baseline.
- Live wizard smoke passed with no browser or console errors.
- Required-description validation, the no-photo dialog, and wizard state progression worked.

No report was submitted during browser validation.
