### PR TITLE
chore(deps): update frontend maintenance dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
 				"@popperjs/core": "^2.11.8",
 				"@rolldown/plugin-babel": "^0.2.2",
 				"@vis.gl/react-google-maps": "^1.8.1",
-				"axios": "^1.14.0",
+				"axios": "^1.18.1",
 				"bootstrap": "^5.3.8",
 				"browser-image-compression": "^2.0.2",
 				"clsx": "^2.1.1",
-				"exifreader": "^4.38.1",
+				"exifreader": "^4.40.1",
 				"jotai": "^2.15.1",
 				"laravel-precognition": "^1.0.2",
 				"react": "^19.2.4",
@@ -33,197 +33,314 @@
 				"babel-plugin-react-compiler": "^1.0.0",
 				"sass": "^1.98.0",
 				"typescript": "^6.0.2",
-				"vite": "^8.0.3"
+				"vite": "^8.1.5"
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+			"integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.28.5",
-				"js-tokens": "^4.0.0",
-				"picocolors": "^1.1.1"
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"js-tokens": "^10.0.0"
 			},
 			"engines": {
-				"node": ">=6.9.0"
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-			"integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+			"integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
-				"node": ">=6.9.0"
+				"node": "^22.18.0 || >=24.11.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+			"integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-compilation-targets": "^7.28.6",
-				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.29.0",
-				"@babel/types": "^7.29.0",
-				"@jridgewell/remapping": "^2.3.5",
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helpers": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@types/gensync": "^1.0.5",
 				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
+				"empathic": "^2.0.1",
 				"gensync": "^1.0.0-beta.2",
+				"import-meta-resolve": "^4.2.0",
 				"json5": "^2.2.3",
-				"semver": "^6.3.1"
+				"obug": "^2.1.1",
+				"semver": "^7.7.3"
 			},
 			"engines": {
-				"node": ">=6.9.0"
+				"node": "^22.18.0 || >=24.11.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/babel"
 			}
 		},
-		"node_modules/@babel/generator": {
-			"version": "7.29.1",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+		"node_modules/@babel/core/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/core/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/core/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/parser": "^7.29.0",
-				"@babel/types": "^7.29.0",
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/generator": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+			"integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
+				"@types/jsesc": "^2.5.0",
 				"jsesc": "^3.0.2"
 			},
 			"engines": {
-				"node": ">=6.9.0"
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/generator/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/generator/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/generator/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+			"integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.28.6",
-				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-validator-option": "^8.0.0",
 				"browserslist": "^4.24.0",
-				"lru-cache": "^5.1.1",
-				"semver": "^6.3.1"
+				"lru-cache": "^11.0.0",
+				"semver": "^7.7.3"
 			},
 			"engines": {
-				"node": ">=6.9.0"
+				"node": "^22.18.0 || >=24.11.0"
 			}
 		},
 		"node_modules/@babel/helper-globals": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+			"integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-module-imports": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/traverse": "^7.28.6",
-				"@babel/types": "^7.28.6"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-module-imports": "^7.28.6",
-				"@babel/helper-validator-identifier": "^7.28.5",
-				"@babel/traverse": "^7.28.6"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
+				"node": "^22.18.0 || >=24.11.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+			"integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
-				"node": ">=6.9.0"
+				"node": "^22.18.0 || >=24.11.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+			"integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.29.0"
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.0"
 			},
 			"engines": {
-				"node": ">=6.9.0"
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/helpers/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/helpers/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/helpers/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+			"integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/types": "^7.29.0"
+				"@babel/types": "^8.0.4"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/parser/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/parser/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/parser/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
 			}
 		},
 		"node_modules/@babel/runtime": {
@@ -236,47 +353,116 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+			"integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/parser": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/code-frame": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0"
 			},
 			"engines": {
-				"node": ">=6.9.0"
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/template/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/template/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/template/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+			"integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.29.0",
-				"debug": "^4.3.1"
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/parser": "^8.0.4",
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.4",
+				"obug": "^2.1.1"
 			},
 			"engines": {
-				"node": ">=6.9.0"
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/traverse/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/traverse/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"node_modules/@babel/traverse/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.28.5"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -511,32 +697,35 @@
 			}
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-			"integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+			"version": "2.0.0-alpha.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+			"integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.1",
+				"@emnapi/wasi-threads": "2.0.1",
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+			"version": "2.0.0-alpha.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+			"integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+			"integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
@@ -628,17 +817,6 @@
 				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
-		"node_modules/@jridgewell/remapping": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			}
-		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -668,27 +846,30 @@
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
+			"integrity": "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@tybys/wasm-util": "^0.10.1"
+				"@tybys/wasm-util": "^0.10.3"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=23.5.0"
 			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/Brooooooklyn"
 			},
 			"peerDependencies": {
-				"@emnapi/core": "^1.7.1",
-				"@emnapi/runtime": "^1.7.1"
+				"@emnapi/core": "^2.0.0-alpha.3",
+				"@emnapi/runtime": "^2.0.0-alpha.3"
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.124.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-			"integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+			"version": "0.139.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+			"integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
@@ -1035,9 +1216,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-			"integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+			"integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1051,9 +1232,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-			"integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+			"integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1067,9 +1248,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-			"integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+			"integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
 			"cpu": [
 				"x64"
 			],
@@ -1083,9 +1264,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-			"integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+			"integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
 			"cpu": [
 				"x64"
 			],
@@ -1099,9 +1280,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-			"integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+			"integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
 			"cpu": [
 				"arm"
 			],
@@ -1115,9 +1296,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-			"integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+			"integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1134,9 +1315,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-			"integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+			"integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1153,9 +1334,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-			"integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+			"integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1172,9 +1353,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-			"integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+			"integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
 			"cpu": [
 				"s390x"
 			],
@@ -1191,9 +1372,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-			"integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+			"integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1210,9 +1391,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-			"integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+			"integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
 			"cpu": [
 				"x64"
 			],
@@ -1229,9 +1410,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-			"integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+			"integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1245,27 +1426,58 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-			"integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+			"integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
 			"cpu": [
 				"wasm32"
 			],
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/core": "1.9.2",
-				"@emnapi/runtime": "1.9.2",
-				"@napi-rs/wasm-runtime": "^1.1.3"
+				"@emnapi/core": "1.11.1",
+				"@emnapi/runtime": "1.11.1",
+				"@napi-rs/wasm-runtime": "^1.1.6"
 			},
 			"engines": {
-				"node": ">=14.0.0"
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-			"integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+			"integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1279,9 +1491,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-			"integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+			"integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
 			"cpu": [
 				"x64"
 			],
@@ -1332,20 +1544,34 @@
 			"license": "MIT"
 		},
 		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
 		},
+		"node_modules/@types/gensync": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
+			"integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@types/google.maps": {
 			"version": "3.58.1",
 			"resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
 			"integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
 			"license": "MIT"
+		},
+		"node_modules/@types/jsesc": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+			"integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/lodash": {
 			"version": "4.17.24",
@@ -1444,6 +1670,18 @@
 				"node": ">=14.6"
 			}
 		},
+		"node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1451,13 +1689,14 @@
 			"license": "MIT"
 		},
 		"node_modules/axios": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-			"integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+			"version": "1.18.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+			"integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.16.0",
 				"form-data": "^4.0.5",
+				"https-proxy-agent": "^5.0.1",
 				"proxy-from-env": "^2.1.0"
 			}
 		},
@@ -1472,9 +1711,9 @@
 			}
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.13",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
-			"integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+			"version": "2.11.6",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.6.tgz",
+			"integrity": "sha512-69D/imtToCsIcAl8WBS2YaRwA4jO/j0HhU+hELqMEu9f54MoUtI6+XH5mrKU8rEFNEk/Ui1I2MK4/JkWacclGw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"bin": {
@@ -1513,9 +1752,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.28.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+			"version": "4.28.7",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+			"integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1533,10 +1772,10 @@
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"baseline-browser-mapping": "^2.10.12",
-				"caniuse-lite": "^1.0.30001782",
-				"electron-to-chromium": "^1.5.328",
-				"node-releases": "^2.0.36",
+				"baseline-browser-mapping": "^2.10.44",
+				"caniuse-lite": "^1.0.30001806",
+				"electron-to-chromium": "^1.5.393",
+				"node-releases": "^2.0.51",
 				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
@@ -1576,9 +1815,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001782",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
-			"integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
+			"version": "1.0.30001806",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+			"integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1652,7 +1891,6 @@
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ms": "^2.1.3"
 			},
@@ -1698,11 +1936,21 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.329",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.329.tgz",
-			"integrity": "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ==",
+			"version": "1.5.397",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.397.tgz",
+			"integrity": "sha512-khGTy9U9x02KEtsKM8vx5A62BsRmcOsIgDpWr1ImE32Ax8GxHGPHZf+Eu9H8zOOyHJnB0jTbseyTHbq2XCT8yw==",
 			"license": "ISC",
 			"peer": true
+		},
+		"node_modules/empathic": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+			"integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			}
 		},
 		"node_modules/es-define-property": {
 			"version": "1.0.1",
@@ -1760,9 +2008,9 @@
 			}
 		},
 		"node_modules/exifreader": {
-			"version": "4.38.1",
-			"resolved": "https://registry.npmjs.org/exifreader/-/exifreader-4.38.1.tgz",
-			"integrity": "sha512-VUQ8pnWJHpnQXPQLgx4XBwjhj+eE0f5t4KhVFn6BnnTYKLf79DfjVRntR5061qE9NZgx2ohvE+JLXe/FWfCaAA==",
+			"version": "4.40.1",
+			"resolved": "https://registry.npmjs.org/exifreader/-/exifreader-4.40.1.tgz",
+			"integrity": "sha512-Xavsts17ZYZoxUsUn+HCvGf8LB2ry7/pLSk2bYhXPGNLKciQDOxsY2EoytnKWfGmBRm4yvHVkw8RWsG5J8s3pA==",
 			"hasInstallScript": true,
 			"license": "MPL-2.0",
 			"optionalDependencies": {
@@ -1813,16 +2061,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -1939,9 +2187,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -1950,12 +2198,36 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/immutable": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-			"integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+			"integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
 			"devOptional": true,
 			"license": "MIT"
+		},
+		"node_modules/import-meta-resolve": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+			"integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
@@ -2010,9 +2282,9 @@
 			}
 		},
 		"node_modules/js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
 			"license": "MIT",
 			"peer": true
 		},
@@ -2320,13 +2592,13 @@
 			"license": "MIT"
 		},
 		"node_modules/lru-cache": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-			"license": "ISC",
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"license": "BlueOak-1.0.0",
 			"peer": true,
-			"dependencies": {
-				"yallist": "^3.0.2"
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/math-intrinsics": {
@@ -2363,13 +2635,12 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -2392,11 +2663,14 @@
 			"optional": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.36",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-			"integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+			"version": "2.0.51",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+			"integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
 			"license": "MIT",
-			"peer": true
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/object-inspect": {
 			"version": "1.13.4",
@@ -2410,6 +2684,20 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/obug": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+			"integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2417,9 +2705,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -2461,9 +2749,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.14",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+			"version": "8.5.24",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+			"integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2480,7 +2768,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -2498,12 +2786,13 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-			"integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+			"version": "6.15.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.1.0"
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -2554,13 +2843,13 @@
 			"license": "MIT"
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-			"integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+			"integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.124.0",
-				"@rolldown/pluginutils": "1.0.0-rc.15"
+				"@oxc-project/types": "=0.139.0",
+				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
 				"rolldown": "bin/cli.mjs"
@@ -2569,27 +2858,27 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.0-rc.15",
-				"@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-				"@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-				"@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+				"@rolldown/binding-android-arm64": "1.1.5",
+				"@rolldown/binding-darwin-arm64": "1.1.5",
+				"@rolldown/binding-darwin-x64": "1.1.5",
+				"@rolldown/binding-freebsd-x64": "1.1.5",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+				"@rolldown/binding-linux-arm64-gnu": "1.1.5",
+				"@rolldown/binding-linux-arm64-musl": "1.1.5",
+				"@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+				"@rolldown/binding-linux-s390x-gnu": "1.1.5",
+				"@rolldown/binding-linux-x64-gnu": "1.1.5",
+				"@rolldown/binding-linux-x64-musl": "1.1.5",
+				"@rolldown/binding-openharmony-arm64": "1.1.5",
+				"@rolldown/binding-wasm32-wasi": "1.1.5",
+				"@rolldown/binding-win32-arm64-msvc": "1.1.5",
+				"@rolldown/binding-win32-x64-msvc": "1.1.5"
 			}
 		},
 		"node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-			"integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 			"license": "MIT"
 		},
 		"node_modules/sass": {
@@ -2620,24 +2909,27 @@
 			"license": "MIT"
 		},
 		"node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
 			"license": "ISC",
 			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/side-channel": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3",
-				"side-channel-list": "^1.0.0",
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
 				"side-channel-map": "^1.0.1",
 				"side-channel-weakmap": "^1.0.2"
 			},
@@ -2649,13 +2941,13 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
+				"object-inspect": "^1.13.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -2727,13 +3019,13 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.15",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"license": "MIT",
 			"dependencies": {
 				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3"
+				"picomatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -2817,16 +3109,16 @@
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "8.0.8",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-			"integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+			"integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
-				"picomatch": "^4.0.4",
-				"postcss": "^8.5.8",
-				"rolldown": "1.0.0-rc.15",
-				"tinyglobby": "^0.2.15"
+				"picomatch": "^4.0.5",
+				"postcss": "^8.5.17",
+				"rolldown": "~1.1.5",
+				"tinyglobby": "^0.2.17"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -2842,7 +3134,7 @@
 			},
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
-				"@vitejs/devtools": "^0.1.0",
+				"@vitejs/devtools": "^0.3.0",
 				"esbuild": "^0.27.0 || ^0.28.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",
@@ -2906,13 +3198,6 @@
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
-		},
-		"node_modules/yallist": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-			"license": "ISC",
-			"peer": true
 		},
 		"node_modules/yet-another-react-lightbox": {
 			"version": "3.32.0",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
 		"@popperjs/core": "^2.11.8",
 		"@rolldown/plugin-babel": "^0.2.2",
 		"@vis.gl/react-google-maps": "^1.8.1",
-		"axios": "^1.14.0",
+		"axios": "^1.18.1",
 		"bootstrap": "^5.3.8",
 		"browser-image-compression": "^2.0.2",
 		"clsx": "^2.1.1",
-		"exifreader": "^4.38.1",
+		"exifreader": "^4.40.1",
 		"jotai": "^2.15.1",
 		"laravel-precognition": "^1.0.2",
 		"react": "^19.2.4",
@@ -41,6 +41,6 @@
 		"babel-plugin-react-compiler": "^1.0.0",
 		"sass": "^1.98.0",
 		"typescript": "^6.0.2",
-		"vite": "^8.0.3"
+		"vite": "^8.1.5"
 	}
 }


### PR DESCRIPTION
## Summary

Update the grouped frontend maintenance dependencies from Dependabot PR #96:

- Axios 1.18.1
- ExifReader 4.40.1
- Vite 8.1.5
- Babel 8.0.1
- form-data 4.0.6
- immutable 5.1.9
- PostCSS 8.5.24
- qs 6.15.3

The duplicate standalone Axios PR #94 has already been closed.

## Why

These updates share one npm lockfile and were validated as one resolved dependency graph rather than as interleaved lockfile rewrites.

## Validation

- Clean forced Compose rebuild passed.
- Docker `npm ci` completed with zero vulnerabilities.
- Exact installed and locked versions were confirmed.
- Production Vite build passed with only the existing chunk-size warning.
- Django system check passed.
- Backend suite matched the existing 194-test baseline.
- Existing Chromium EXIF wizard tests passed.
- Additional real-image upload validation passed with no console or page errors.

No report was submitted during browser validation.
