### PR TITLE
chore(deps): group dependabot updates and fix pip directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,49 @@
 version: 2
 updates:
+  # Python dependencies live in the root Pipfile / Pipfile.lock, not /docker.
   - package-ecosystem: "pip"
-    directory: "/docker"
+    directory: "/"
     schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "*"
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Los_Angeles"
+    groups:
+      python-production:
         dependency-type: "production"
+      python-development:
+        dependency-type: "development"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "*"
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Los_Angeles"
+    groups:
+      # Listed first: a dependency joins the first group whose rules it matches.
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+          - "@inertiajs/react"
+          - "babel-plugin-react-compiler"
+      npm-production:
         dependency-type: "production"
+      npm-development:
+        dependency-type: "development"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Los_Angeles"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description

Dependabot was opening one PR per dependency because no `groups:` were configured — ungrouped is the default for version updates. This adds grouping to all three ecosystems and fixes a couple of related config problems found along the way.

- **Grouping.** React family in one PR (`react`, `react-dom`, their `@types`, `@inertiajs/react`, `babel-plugin-react-compiler`), the rest split by production vs development, and all `github-actions` bumps collapsed into a single PR. Group order matters — a dependency joins the first group it matches — so `react` is listed above the prod/dev groups to keep the family from splitting across that boundary. There's a comment in the file noting this so it doesn't get reordered later.
- **pip directory.** It was watching `/docker`, where `requirements-dev.txt` is empty and `requirements-test.txt` holds only `tblib`, `model_bakery`, `coverage`. The real dependencies live in the root `Pipfile`/`Pipfile.lock` — Django, Pillow, celery, gunicorn, psycopg2-binary, sentry-sdk — and were getting **zero** update PRs. This also explains why the only pip PR we ever saw was #87 (tblib, from the test file).
- **devDependencies.** Dropped the `dependency-type: "production"` allow rules, so biome, playwright, typescript, vite, sass and the `@types/*` packages are now covered. They land in their own `*-development` group, so they're easy to batch-merge or ignore separately from production bumps.
- **Schedule.** Pinned to Monday 06:00 `America/Los_Angeles` (that zone string handles the PST/PDT switch, so it stays 6am local year-round). Moved pip and npm from `daily` to `weekly`, since grouping makes daily noisier than it needs to be.

Note this only governs **version** updates — security updates ignore the schedule and still fire as soon as an advisory matches our lockfiles.

## Follow-ups after merge

- `deps/group-ci-actions-2026-07` and the other `deps/group-*` branches were manual regroupings of exactly what this config now does automatically.
- Existing open Dependabot PRs won't regroup retroactively. Commenting `@dependabot recreate` on #85/#86/#88/#89 would collapse them into one `github-actions` PR.
- Expect an initial batch from pip once this lands — that directory has been effectively unwatched. The Pipfile pins are reasonably current (Django 6.0.2, Pillow 12.1.0), so it shouldn't be huge.

## Checklist

- [x] I have reviewed my code and made sure it meets the project's coding standards and followed the contributing guide.
- [x] I have tested my code thoroughly (if needed) to ensure it works as expected.
- [ ] I have documented my code (if needed) in the README.md.
- [x] I have checked that this PR doesn't introduce any accessibility issues.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Other (performance, refactoring, documentation, dependency, configuration, security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)