### PR TITLE
fix: show non-field wizard errors

### DIFF
--- a/frontend/src/features/reportWizard.tsx
+++ b/frontend/src/features/reportWizard.tsx
@@ -1,5 +1,6 @@
 import { useForm } from "@inertiajs/react";
 import { useState } from "react";
+import AnnouncementBanner from "../components/wizard/announcementBanner";
 import ConfirmNoImagesDialog from "../components/wizard/confirmNoImagesDialog";
 import {
 	allFields,
@@ -7,7 +8,6 @@ import {
 	Steps,
 	type WizardFormData,
 } from "../components/wizard/fields";
-import AnnouncementBanner from "../components/wizard/announcementBanner";
 import StepFour from "../components/wizard/steps/four";
 import StepOne from "../components/wizard/steps/one";
 import StepThree from "../components/wizard/steps/three";
@@ -16,6 +16,8 @@ import type {
 	CategoryWithSpecies,
 	ContactInfo,
 } from "../components/wizard/types";
+
+const wizardFieldNames = new Set<string>(allFields);
 
 interface FormWizardProps {
 	/** Logged-in user's contact info, pre-fills step 4. */
@@ -60,7 +62,9 @@ export default function FormWizard(props: FormWizardProps) {
 							Report an Invader
 						</h1>
 						<AnnouncementBanner>
-						<a href="/reports/create">Click here to use the Hotline classic reporting tool.</a>
+							<a href="/reports/create">
+								Click here to use the Hotline classic reporting tool.
+							</a>
 						</AnnouncementBanner>
 						<div className="card rounded-4 shadow-md">
 							<div className="card-body p-3 p-md-4">
@@ -186,26 +190,14 @@ export default function FormWizard(props: FormWizardProps) {
 										</div>
 									</>
 								)}
-								{/* Shows errors not used by a specific field. In theory should never show up if everything is working properly */}
-								{import.meta.env.DEV &&
-									Boolean(
-										Object.entries(form.errors).filter(
-											// @ts-expect-error
-											([k]) => !allFields.includes(k),
-										).length,
-									) && (
-										<>
-											Debug Errors:{" "}
-											{JSON.stringify(
-												Object.fromEntries(
-													Object.entries(form.errors).filter(
-														// @ts-expect-error
-														([k]) => !allFields.includes(k),
-													),
-												),
-											)}
-										</>
-									)}
+								{/* Show errors that are not tied to a wizard field. */}
+								{Object.entries(form.errors)
+									.filter(([field]) => !wizardFieldNames.has(field))
+									.map(([field, error]) => (
+										<div key={field} className="alert alert-danger mt-3 mb-0">
+											{String(error)}
+										</div>
+									))}
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
## Summary

- Show server errors that are not tied to a wizard field as visible alerts.
- Remove the development-only JSON error dump and its type suppressions.
- Keep the change separate from the Inertia dependency migration in #121.
- AnnouncementBanner import moved and use is reformatted, but no real changes.

This extracts the remaining user-facing behavior from #100 so that dependency PR can be closed as superseded.

## Validation

- `npm ci --no-audit --no-fund`
- `npx @biomejs/biome check frontend/src/features/reportWizard.tsx`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
