### PR TITLE
chore(deps): update ExifReader and Immutable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"bootstrap": "^5.3.8",
 				"browser-image-compression": "^2.0.2",
 				"clsx": "^2.1.1",
-				"exifreader": "^4.38.1",
+				"exifreader": "^4.40.1",
 				"jotai": "^2.15.1",
 				"laravel-precognition": "^1.0.2",
 				"react": "^19.2.4",
@@ -1760,9 +1760,9 @@
 			}
 		},
 		"node_modules/exifreader": {
-			"version": "4.38.1",
-			"resolved": "https://registry.npmjs.org/exifreader/-/exifreader-4.38.1.tgz",
-			"integrity": "sha512-VUQ8pnWJHpnQXPQLgx4XBwjhj+eE0f5t4KhVFn6BnnTYKLf79DfjVRntR5061qE9NZgx2ohvE+JLXe/FWfCaAA==",
+			"version": "4.40.1",
+			"resolved": "https://registry.npmjs.org/exifreader/-/exifreader-4.40.1.tgz",
+			"integrity": "sha512-Xavsts17ZYZoxUsUn+HCvGf8LB2ry7/pLSk2bYhXPGNLKciQDOxsY2EoytnKWfGmBRm4yvHVkw8RWsG5J8s3pA==",
 			"hasInstallScript": true,
 			"license": "MPL-2.0",
 			"optionalDependencies": {
@@ -1951,9 +1951,9 @@
 			}
 		},
 		"node_modules/immutable": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-			"integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+			"integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
 			"devOptional": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"bootstrap": "^5.3.8",
 		"browser-image-compression": "^2.0.2",
 		"clsx": "^2.1.1",
-		"exifreader": "^4.38.1",
+		"exifreader": "^4.40.1",
 		"jotai": "^2.15.1",
 		"laravel-precognition": "^1.0.2",
 		"react": "^19.2.4",


### PR DESCRIPTION
## Summary

- Update ExifReader from 4.38.1 to 4.40.1.
- Update the transitive Immutable lockfile resolution from 5.1.5 to 5.1.9 without adding it as a direct dependency.

This extracts the remaining focused dependency updates from #99 while #121 and #124 cover the other superseding frontend changes.

## Validation

- `npm ci --no-audit --no-fund`
- `npm run build`
- `git diff --check`